### PR TITLE
Tiebreaking

### DIFF
--- a/geocoder.py
+++ b/geocoder.py
@@ -100,6 +100,13 @@ def add_address_file_fields(
         addresses, how="left", left_on="output_address", right_on="street_address"
     ).rename(rename_mapping)
 
+    joined_lf = joined_lf.with_columns(
+        pl.when(pl.col("geocode_lat").is_not_null())
+        .then(pl.lit("address_file"))
+        .otherwise("match_type")
+        .alias("match_type")
+    )
+
     return joined_lf
 
 

--- a/tests/test_ais_lookup.py
+++ b/tests/test_ais_lookup.py
@@ -59,6 +59,122 @@ def test_ais_lookup_creates_address_search_url(monkeypatch):
         "is_multiple_match": False
     }
 
+def test_ais_lookup_tiebreaks(monkeypatch):
+    created = {}
+
+    class FakeResponse:
+        def __init__(self, data, status_code=200):
+            self._data = data
+            self.status_code = status_code
+
+        def __getitem__(self, k):
+            return self._data[k]
+
+        def __bool__(self):
+            return True
+
+        def json(self):
+            return self._data
+
+    class FakeSession:
+        def get(self, *a, **k):
+            raise AssertionError("should be patched")
+
+    def fake_get(self, url, params=None, timeout=None, **kwargs):
+        created["url"] = url
+        created["params"] = params
+        return FakeResponse(
+            {
+                "features": [
+                    {
+                        "properties": {"street_address": "1234 N MARKET ST", "zip_code": "19107"},
+                        "geometry": {"coordinates": [-75.16, 39.95]},
+                    },
+                    {
+                        "properties": {"street_address": "1234 S MARKET ST", "zip_code": "11111"},
+                        "geometry": {"coordinates": [-75.16, 39.95]},
+                    }
+
+                ]
+            },
+            200,
+        )
+
+    monkeypatch.setattr(FakeSession, "get", fake_get)
+    sess = FakeSession()
+
+    result = ais_lookup.ais_lookup(sess, "1234", "1234 mkt st", "19107", [])
+
+    assert created["url"] == "https://api.phila.gov/ais/v1/search/1234 mkt st"
+    assert created["params"] == {"gatekeeperKey": "1234"}
+    assert result == {
+        "geocode_lat": "39.95",
+        "geocode_lon": "-75.16",
+        "is_addr": True,
+        "is_philly_addr": True,
+        "output_address": "1234 N MARKET ST",
+        "match_type": "ais",
+        "is_multiple_match": False
+    }
+
+def test_ais_lookup_returns_no_match_if_tiebreak_fails(monkeypatch):
+    created = {}
+
+    class FakeResponse:
+        def __init__(self, data, status_code=200):
+            self._data = data
+            self.status_code = status_code
+
+        def __getitem__(self, k):
+            return self._data[k]
+
+        def __bool__(self):
+            return True
+
+        def json(self):
+            return self._data
+
+    class FakeSession:
+        def get(self, *a, **k):
+            raise AssertionError("should be patched")
+
+    def fake_get(self, url, params=None, timeout=None, **kwargs):
+        created["url"] = url
+        created["params"] = params
+        return FakeResponse(
+            {
+                "features": [
+                    {
+                        "properties": {"street_address": "1234 N MARKET ST", "zip_code": "22222"},
+                        "geometry": {"coordinates": [-75.16, 39.95]},
+                    },
+                    {
+                        "properties": {"street_address": "1234 S MARKET ST", "zip_code": "11111"},
+                        "geometry": {"coordinates": [-75.16, 39.95]},
+                    }
+
+                ]
+            },
+            200,
+        )
+
+    monkeypatch.setattr(FakeSession, "get", fake_get)
+    sess = FakeSession()
+
+    result = ais_lookup.ais_lookup(sess, "1234", "1234 mkt st", "19107", [])
+
+    assert created["url"] == "https://api.phila.gov/ais/v1/search/1234 mkt st"
+    assert created["params"] == {"gatekeeperKey": "1234"}
+    assert result == {
+        "geocode_lat": None,
+        "geocode_lon": None,
+        "is_addr": False,
+        "is_philly_addr": False,
+        "output_address": None,
+        "match_type": "ais",
+        "is_multiple_match": True
+    }
+
 
 def test_false_address_returns_input_address_if_bad_address(monkeypatch):
 

--- a/tests/test_ais_lookup.py
+++ b/tests/test_ais_lookup.py
@@ -29,9 +29,14 @@ def test_ais_lookup_creates_address_search_url(monkeypatch):
             {
                 "features": [
                     {
-                        "properties": {"street_address": "1234 MARKET ST"},
+                        "properties": {"street_address": "1234 MARKET ST", "zip_code": "19107"},
+                        "geometry": {"coordinates": [-75.16, 39.95]},
+                    },
+                    {
+                        "properties": {"street_address": "1234 MARKET ST", "zip_code": "11111"},
                         "geometry": {"coordinates": [-75.16, 39.95]},
                     }
+
                 ]
             },
             200,
@@ -40,7 +45,7 @@ def test_ais_lookup_creates_address_search_url(monkeypatch):
     monkeypatch.setattr(FakeSession, "get", fake_get)
     sess = FakeSession()
 
-    result = ais_lookup.ais_lookup(sess, "1234", "1234 mkt st", [])
+    result = ais_lookup.ais_lookup(sess, "1234", "1234 mkt st", "19107", [])
 
     assert created["url"] == "https://api.phila.gov/ais/v1/search/1234 mkt st"
     assert created["params"] == {"gatekeeperKey": "1234"}
@@ -50,6 +55,8 @@ def test_ais_lookup_creates_address_search_url(monkeypatch):
         "is_addr": True,
         "is_philly_addr": True,
         "output_address": "1234 MARKET ST",
+        "match_type": "ais",
+        "is_multiple_match": False
     }
 
 
@@ -82,12 +89,14 @@ def test_false_address_returns_input_address_if_bad_address(monkeypatch):
     sess = FakeSession()
 
     address = "123 fake st"
-    result = ais_lookup.ais_lookup(sess, "1234", address, [])
-    
+    result = ais_lookup.ais_lookup(sess, "1234", address, zip=None, enrichment_fields=[])
+
     assert result == {
         "geocode_lat": None,
         "geocode_lon": None,
         "is_addr": False,
         "is_philly_addr": False,
         "output_address": "123 fake st",
+        "is_multiple_match": False,
+        "match_type": None
     }

--- a/tests/test_tomtom_lookup.py
+++ b/tests/test_tomtom_lookup.py
@@ -1,26 +1,40 @@
 import utils.tomtom_lookup as tomtom_lookup
 
-json_response_match =  {'spatialReference': {'wkid': 4326, 'latestWkid': 4326},
-    'candidates': [{'address': '1234 Market St, Philadelphia, Pennsylvania, 19107',
-    'location': {'x': -75.16047189802985, 'y': 39.951918251135154},
-    'score': 100,
-    'attributes': {},
-    'extent': {'xmin': -75.16147189802986,
-        'ymin': 39.95091825113516,
-        'xmax': -75.15947189802985,
-        'ymax': 39.95291825113515}},
-    {'address': '1234 Market St, Gloucester City, New Jersey, 08030',
-    'location': {'x': -75.11192847164241, 'y': 39.88775918851947},
-    'score': 97.26,
-    'attributes': {},
-    'extent': {'xmin': -75.11292847164242,
-        'ymin': 39.88675918851947,
-        'xmax': -75.11092847164241,
-        'ymax': 39.888759188519465}}
-    ]}
+json_response_match = {
+    "spatialReference": {"wkid": 4326, "latestWkid": 4326},
+    "candidates": [
+        {
+            "address": "1234 Market St, Philadelphia, Pennsylvania, 19107",
+            "location": {"x": -75.16047189802985, "y": 39.951918251135154},
+            "score": 100,
+            "attributes": {},
+            "extent": {
+                "xmin": -75.16147189802986,
+                "ymin": 39.95091825113516,
+                "xmax": -75.15947189802985,
+                "ymax": 39.95291825113515,
+            },
+        },
+        {
+            "address": "1234 Market St, Gloucester City, New Jersey, 08030",
+            "location": {"x": -75.11192847164241, "y": 39.88775918851947},
+            "score": 97.26,
+            "attributes": {},
+            "extent": {
+                "xmin": -75.11292847164242,
+                "ymin": 39.88675918851947,
+                "xmax": -75.11092847164241,
+                "ymax": 39.888759188519465,
+            },
+        },
+    ],
+}
 
-json_response_nonmatch = {'spatialReference': {'wkid': 4326, 'latestWkid': 4326},
-    'candidates': []}
+json_response_nonmatch = {
+    "spatialReference": {"wkid": 4326, "latestWkid": 4326},
+    "candidates": [],
+}
+
 
 def test_false_address_returns_none_if_bad_address(monkeypatch):
 
@@ -43,9 +57,7 @@ def test_false_address_returns_none_if_bad_address(monkeypatch):
             raise AssertionError("Should be patched")
 
     def fake_get(self, url, params=None, timeout=None, **kwargs):
-        return FakeResponse(
-            {}, 404
-        )
+        return FakeResponse({}, 404)
 
     monkeypatch.setattr(FakeSession, "get", fake_get)
     sess = FakeSession()
@@ -56,4 +68,5 @@ def test_false_address_returns_none_if_bad_address(monkeypatch):
         "geocode_lat": None,
         "geocode_lon": None,
         "output_address": "",
+        "match_type": None,
     }

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -33,15 +33,44 @@ class RateLimiter:
 limiter = RateLimiter(10)
 
 
+def tiebreak(response: dict, zip) -> dict:
+    """
+    If more than one result is returned by AIS, tiebreak by checking zip code.
+    If no zip code is provided, return None and a flag that indicates a
+    duplicate match.
+
+    Returns:
+        A dict with the zipcode-matched record, or if no match, None.
+    """
+
+    candidates = []
+    for candidate in response.json()["features"]:
+        
+        if candidate["properties"].get("zip_code", "") == zip:
+            candidates.append(candidate)
+
+    if len(candidates) == 1:
+        return candidates[0]
+
+    # If multiple candidates have zip code,
+    # or no candidates have zip code,
+    # we cannot tie break. Return None.
+    return None
+
+
 # Code adapted from Alex Waldman and Roland MacDavid
 # https://github.com/CityOfPhiladelphia/databridge-etl-tools/blob/master/databridge_etl_tools/ais_geocoder/ais_request.py
-@retry(
-    wait_exponential_multiplier=1000,
-    wait_exponential_max=10000,
-    stop_max_attempt_number=5,
-)
+# @retry(
+#     wait_exponential_multiplier=1000,
+#     wait_exponential_max=10000,
+#     stop_max_attempt_number=5,
+# )
 def ais_lookup(
-    sess: requests.Session, api_key: str, address: str, enrichment_fields: list
+    sess: requests.Session,
+    api_key: str,
+    address: str,
+    zip: str = None,
+    enrichment_fields: list = [],
 ) -> dict:
     """
     Given a passyunk-normalized address, looks up whether or not it is in the
@@ -70,7 +99,29 @@ def ais_lookup(
 
     out_data = {}
     if response.status_code == 200:
-        r_json = response.json()["features"][0]
+
+        if len(response.json()["features"]) > 1:
+            r_json = tiebreak(response, zip)
+
+            # If no matches are found, return
+            # null values for most fields.
+            if not r_json:
+                out_data["output_address"] = None
+                out_data["is_addr"] = False
+                out_data["is_philly_addr"] = False
+                out_data["geocode_lat"] = None
+                out_data["geocode_lon"] = None
+                out_data["is_multiple_match"] = True
+                out_data["match_type"] = "ais"
+
+                for field in enrichment_fields:
+                    out_data[field] = None
+
+                return out_data
+
+        else:
+            r_json = response.json()["features"][0]
+
         address = r_json.get("properties", "").get("street_address", "")
 
         try:
@@ -84,6 +135,8 @@ def ais_lookup(
         out_data["is_philly_addr"] = True
         out_data["geocode_lat"] = str(lat)
         out_data["geocode_lon"] = str(lon)
+        out_data["is_multiple_match"] = False
+        out_data["match_type"] = "ais"
 
         for field in enrichment_fields:
             field_value = r_json.get("properties", "").get(field, "")
@@ -99,11 +152,14 @@ def ais_lookup(
 
         return out_data
 
+    # If no match, return none
     out_data["output_address"] = address
     out_data["is_addr"] = False
     out_data["is_philly_addr"] = False
     out_data["geocode_lat"] = None
     out_data["geocode_lon"] = None
+    out_data["is_multiple_match"] = False
+    out_data["match_type"] = None
 
     for field in enrichment_fields:
         out_data[field] = None
@@ -112,10 +168,14 @@ def ais_lookup(
 
 
 def throttle_ais_lookup(
-    sess: requests.Session, api_key: str, address: str, enrichment_fields: list
+    sess: requests.Session,
+    api_key: str,
+    address: str,
+    zip: str = None,
+    enrichment_fields: list = [],
 ) -> dict:
     """
     Helper function to throttle the number of API requests to 10 per second.
     """
     limiter.wait()
-    return ais_lookup(sess, api_key, address, enrichment_fields)
+    return ais_lookup(sess, api_key, address, zip, enrichment_fields)

--- a/utils/parse_address.py
+++ b/utils/parse_address.py
@@ -139,5 +139,5 @@ def parse_address(parser, address: str) -> tuple[str, bool, bool]:
         "is_addr": is_addr,
         "is_philly_addr": is_philly_addr,
         "is_multiple_match": False,
-        "match_type": "passyunk"
+        "match_type": None,
     }

--- a/utils/parse_address.py
+++ b/utils/parse_address.py
@@ -53,6 +53,23 @@ def flag_non_philly_address(
     return False
 
 
+def find_zip_field(config_path) -> str:
+    """
+    Identifies the name of the zip code field.
+    """
+
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    addr_fields = config.get("address_fields") or {}
+    zip_field = addr_fields.get("zip", "")
+
+    if zip_field:
+        return zip_field
+
+    return None
+
+
 def find_address_fields(config_path) -> List[str]:
     """
     Parses which address fields to consider in the input file based on
@@ -121,4 +138,6 @@ def parse_address(parser, address: str) -> tuple[str, bool, bool]:
         "output_address": output_address,
         "is_addr": is_addr,
         "is_philly_addr": is_philly_addr,
+        "is_multiple_match": False,
+        "match_type": "passyunk"
     }

--- a/utils/tomtom_lookup.py
+++ b/utils/tomtom_lookup.py
@@ -27,10 +27,7 @@ def tomtom_lookup(sess: requests.Session, address: str) -> dict:
     tomtom_url = "https://citygeo-geocoder-aws.phila.city/arcgis/rest/services/TomTom/US_StreetAddress/GeocodeServer/findAddressCandidates"
 
     # Need to specify json format, HTML by default
-    params = {
-        'Address': address,
-        'f': 'pjson'
-    }
+    params = {"Address": address, "f": "pjson"}
 
     response = sess.get(tomtom_url, params=params, timeout=10)
 
@@ -42,7 +39,7 @@ def tomtom_lookup(sess: requests.Session, address: str) -> dict:
     out_data = {}
     if response.status_code == 200:
         # TomTom returns an empty list if no addresses match
-        if response.json()['candidates']:
+        if response.json()["candidates"]:
             # First response should be most probable match
             r_json = response.json()["candidates"][0]
             address = r_json.get("address", "")
@@ -57,21 +54,21 @@ def tomtom_lookup(sess: requests.Session, address: str) -> dict:
             out_data["output_address"] = address
             out_data["geocode_lat"] = str(lat)
             out_data["geocode_lon"] = str(lon)
+            out_data["match_type"] = "tomtom"
 
             return out_data
 
     out_data["output_address"] = ""
     out_data["geocode_lat"] = None
     out_data["geocode_lon"] = None
+    out_data["match_type"] = None
 
     return out_data
 
-def throttle_tomtom_lookup(
-    sess: requests.Session, address: str
-) -> dict:
+
+def throttle_tomtom_lookup(sess: requests.Session, address: str) -> dict:
     """
     Helper function to throttle the number of API requests to 10 per second.
     """
     limiter.wait()
     return tomtom_lookup(sess, address)
-


### PR DESCRIPTION
The tool will now attempt to use zip code where provided to choose an address in cases where AIS returns multiple addresses. If zip code fails to distinguish between addresses, the tool will return no match and an "is_multiple_match" flag.

Additionally, includes a "match_type" flag for informational and debugging purposes.