### PR TITLE
12 add option to choose between srid 4326 and srid 2272

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ enrichment_fields:
   - census_block_2020
 ```
 
+6. List which SRIDs should be returned. SRID refers to the format of the coordinate system. There are two options: 4326 and 2272. 4326 is the WGS84 standard, and will be output as `geocode_lat` and `geocode_lon` and 2272 Southern Pennsylvania Projection and is output as `geocode_x` and `geocode_y`. 
+
+```
+# Which SRIDs to return for geocoding
+srid_4326: true
+srid_2272: true
+```
+
 The full config file should look something like this:
 ```
 # Connection Credentials
@@ -119,9 +127,12 @@ enrichment_fields:
   - census_tract_2020
   - census_block_group_2020
   - census_block_2020
-```
 
-Note that if one of the input fields has a column the same name as 
+
+# Which SRIDs to return for geocoding
+srid_4326: true
+srid_2272: true
+``` 
 
 6. You're now ready to run the geocoder:
 

--- a/config_example.yml
+++ b/config_example.yml
@@ -25,3 +25,7 @@ enrichment_fields:
   # ADD MORE FIELDS BELOW, EG: 
   # - census_tract_2010
   # - seg_id
+
+# Which SRIDs to return for geocoding
+srid_4326: true
+srid_2272: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "ruff>=0.14.9",
     "setuptools>=80.9.0",
     "usaddress>=0.5.16",
-    "wheel>=0.45.1",
+    "wheel>=0.46.2",
 ]
 
 [tool.uv.sources]

--- a/tests/test_ais_lookup.py
+++ b/tests/test_ais_lookup.py
@@ -3,6 +3,7 @@ import utils.ais_lookup as ais_lookup
 
 def test_ais_lookup_creates_address_search_url(monkeypatch):
     created = {}
+    call_count = {"count": 0}
 
     class FakeResponse:
         def __init__(self, data, status_code=200):
@@ -23,30 +24,46 @@ def test_ais_lookup_creates_address_search_url(monkeypatch):
             raise AssertionError("should be patched")
 
     def fake_get(self, url, params=None, timeout=None, **kwargs):
+        call_count["count"] += 1
         created["url"] = url
         created["params"] = params
-        return FakeResponse(
-            {
-                "search_type": "address",
-                "features": [
-                    {
-                        "properties": {
-                            "street_address": "1234 MARKET ST",
-                            "zip_code": "19107",
+        
+        # First call (SRID 4326)
+        if call_count["count"] == 1:
+            return FakeResponse(
+                {
+                    "search_type": "address",
+                    "features": [
+                        {
+                            "properties": {
+                                "street_address": "1234 MARKET ST",
+                                "zip_code": "19107",
+                            },
+                            "geometry": {"coordinates": [-75.16, 39.95]},
                         },
-                        "geometry": {"coordinates": [-75.16, 39.95]},
-                    },
-                    {
-                        "properties": {
-                            "street_address": "1234 MARKET ST",
-                            "zip_code": "11111",
+                        {
+                            "properties": {
+                                "street_address": "1234 MARKET ST",
+                                "zip_code": "11111",
+                            },
+                            "geometry": {"coordinates": [-75.16, 39.95]},
                         },
-                        "geometry": {"coordinates": [-75.16, 39.95]},
-                    },
-                ],
-            },
-            200,
-        )
+                    ],
+                },
+                200,
+            )
+        # Second call (SRID 2272)
+        else:
+            return FakeResponse(
+                {
+                    "features": [
+                        {
+                            "geometry": {"coordinates": [2694393.35, 235982.72]},
+                        }
+                    ],
+                },
+                200,
+            )
 
     monkeypatch.setattr(FakeSession, "get", fake_get)
     sess = FakeSession()
@@ -60,15 +77,16 @@ def test_ais_lookup_creates_address_search_url(monkeypatch):
         existing_is_addr=True,
         existing_is_philly_addr=True,
         original_address="1234 mkt st",
+        fetch_4326=True,
+        fetch_2272=True,
     )
 
-    assert created["url"] in("https://api.phila.gov/ais/v1/search/1234%20mkt%20st?gatekeeperKey=1234&srid=4326&max_range=0",\
-                              "https://api.phila.gov/ais/v1/search/1234%20MARKET%20ST?gatekeeperKey=1234&srid=2272&max_range=0")
+    assert "1234%20mkt%20st" in created["url"] or "1234%20MARKET%20ST" in created["url"]
     assert result == {
         "geocode_lat": "39.95",
         "geocode_lon": "-75.16",
-        "geocode_x": "-75.16",
-        "geocode_y": "39.95",
+        "geocode_x": "2694393.35",
+        "geocode_y": "235982.72",
         "is_addr": True,
         "is_philly_addr": True,
         "output_address": "1234 MARKET ST",
@@ -77,8 +95,152 @@ def test_ais_lookup_creates_address_search_url(monkeypatch):
     }
 
 
+def test_ais_lookup_only_fetches_4326(monkeypatch):
+    created = {}
+
+    class FakeResponse:
+        def __init__(self, data, status_code=200):
+            self._data = data
+            self.status_code = status_code
+
+        def json(self):
+            return self._data
+
+    class FakeSession:
+        def get(self, *a, **k):
+            raise AssertionError("should be patched")
+
+    def fake_get(self, url, params=None, timeout=None, **kwargs):
+        created["url"] = url
+        return FakeResponse(
+            {
+                "search_type": "address",
+                "features": [
+                    {
+                        "properties": {
+                            "street_address": "1234 MARKET ST",
+                            "zip_code": "19107",
+                        },
+                        "geometry": {"coordinates": [-75.16, 39.95]},
+                    }
+                ],
+            },
+            200,
+        )
+
+    monkeypatch.setattr(FakeSession, "get", fake_get)
+    sess = FakeSession()
+
+    result = ais_lookup.ais_lookup(
+        sess,
+        "1234",
+        "1234 mkt st",
+        "19107",
+        [],
+        existing_is_addr=True,
+        existing_is_philly_addr=True,
+        original_address="1234 mkt st",
+        fetch_4326=True,
+        fetch_2272=False,
+    )
+
+    assert result == {
+        "geocode_lat": "39.95",
+        "geocode_lon": "-75.16",
+        "is_addr": True,
+        "is_philly_addr": True,
+        "output_address": "1234 MARKET ST",
+        "match_type": "ais",
+        "is_multiple_match": False,
+    }
+    # Ensure geocode_x and geocode_y are not in result
+    assert "geocode_x" not in result
+    assert "geocode_y" not in result
+
+
+def test_ais_lookup_only_fetches_2272(monkeypatch):
+    created = {}
+    call_count = {"count": 0}
+
+    class FakeResponse:
+        def __init__(self, data, status_code=200):
+            self._data = data
+            self.status_code = status_code
+
+        def json(self):
+            return self._data
+
+    class FakeSession:
+        def get(self, *a, **k):
+            raise AssertionError("should be patched")
+
+    def fake_get(self, url, params=None, timeout=None, **kwargs):
+        call_count["count"] += 1
+        created["url"] = url
+        
+        # First call (initial lookup, always 4326)
+        if call_count["count"] == 1:
+            return FakeResponse(
+                {
+                    "search_type": "address",
+                    "features": [
+                        {
+                            "properties": {
+                                "street_address": "1234 MARKET ST",
+                                "zip_code": "19107",
+                            },
+                            "geometry": {"coordinates": [-75.16, 39.95]},
+                        }
+                    ],
+                },
+                200,
+            )
+        # Second call (SRID 2272)
+        else:
+            return FakeResponse(
+                {
+                    "features": [
+                        {
+                            "geometry": {"coordinates": [2694393.35, 235982.72]},
+                        }
+                    ],
+                },
+                200,
+            )
+
+    monkeypatch.setattr(FakeSession, "get", fake_get)
+    sess = FakeSession()
+
+    result = ais_lookup.ais_lookup(
+        sess,
+        "1234",
+        "1234 mkt st",
+        "19107",
+        [],
+        existing_is_addr=True,
+        existing_is_philly_addr=True,
+        original_address="1234 mkt st",
+        fetch_4326=False,
+        fetch_2272=True,
+    )
+
+    assert result == {
+        "geocode_x": "2694393.35",
+        "geocode_y": "235982.72",
+        "is_addr": True,
+        "is_philly_addr": True,
+        "output_address": "1234 MARKET ST",
+        "match_type": "ais",
+        "is_multiple_match": False,
+    }
+    # Ensure geocode_lat and geocode_lon are not in result
+    assert "geocode_lat" not in result
+    assert "geocode_lon" not in result
+
+
 def test_ais_lookup_tiebreaks(monkeypatch):
     created = {}
+    call_count = {"count": 0}
 
     class FakeResponse:
         def __init__(self, data, status_code=200):
@@ -99,30 +261,46 @@ def test_ais_lookup_tiebreaks(monkeypatch):
             raise AssertionError("should be patched")
 
     def fake_get(self, url, params=None, timeout=None, **kwargs):
+        call_count["count"] += 1
         created["url"] = url
         created["params"] = params
-        return FakeResponse(
-            {
-                "search_type": "address",
-                "features": [
-                    {
-                        "properties": {
-                            "street_address": "1234 N MARKET ST",
-                            "zip_code": "19107",
+        
+        # First call (SRID 4326)
+        if call_count["count"] == 1:
+            return FakeResponse(
+                {
+                    "search_type": "address",
+                    "features": [
+                        {
+                            "properties": {
+                                "street_address": "1234 N MARKET ST",
+                                "zip_code": "19107",
+                            },
+                            "geometry": {"coordinates": [-75.16, 39.95]},
                         },
-                        "geometry": {"coordinates": [-75.16, 39.95]},
-                    },
-                    {
-                        "properties": {
-                            "street_address": "1234 S MARKET ST",
-                            "zip_code": "11111",
+                        {
+                            "properties": {
+                                "street_address": "1234 S MARKET ST",
+                                "zip_code": "11111",
+                            },
+                            "geometry": {"coordinates": [-75.16, 39.95]},
                         },
-                        "geometry": {"coordinates": [-75.16, 39.95]},
-                    },
-                ],
-            },
-            200,
-        )
+                    ],
+                },
+                200,
+            )
+        # Second call (SRID 2272)
+        else:
+            return FakeResponse(
+                {
+                    "features": [
+                        {
+                            "geometry": {"coordinates": [2694393.35, 235982.72]},
+                        }
+                    ],
+                },
+                200,
+            )
 
     monkeypatch.setattr(FakeSession, "get", fake_get)
     sess = FakeSession()
@@ -136,15 +314,16 @@ def test_ais_lookup_tiebreaks(monkeypatch):
         existing_is_addr=True,
         existing_is_philly_addr=True,
         original_address="1234 mkt st",
+        fetch_4326=True,
+        fetch_2272=True,
     )
 
-    assert created["url"] in("https://api.phila.gov/ais/v1/search/1234%20mkt%20st?gatekeeperKey=1234&srid=4326&max_range=0",\
-                              "https://api.phila.gov/ais/v1/search/1234%20N%20MARKET%20ST?gatekeeperKey=1234&srid=2272&max_range=0")
+    assert "1234%20mkt%20st" in created["url"] or "1234%20N%20MARKET%20ST" in created["url"]
     assert result == {
         "geocode_lat": "39.95",
         "geocode_lon": "-75.16",
-        "geocode_x": "-75.16",
-        "geocode_y": "39.95",
+        "geocode_x": "2694393.35",
+        "geocode_y": "235982.72",
         "is_addr": True,
         "is_philly_addr": True,
         "output_address": "1234 N MARKET ST",
@@ -212,6 +391,8 @@ def test_ais_lookup_returns_no_match_if_tiebreak_fails(monkeypatch):
         existing_is_addr=True,
         existing_is_philly_addr=True,
         original_address="1234 mkt st",
+        fetch_4326=True,
+        fetch_2272=True,
     )
 
     assert created["url"] == "https://api.phila.gov/ais/v1/search/1234%20mkt%20st?gatekeeperKey=1234&srid=4326&max_range=0"
@@ -269,6 +450,8 @@ def test_false_address_returns_input_address_if_bad_address(monkeypatch):
         existing_is_addr=False,
         existing_is_philly_addr=False,
         original_address=address,
+        fetch_4326=True,
+        fetch_2272=True,
     )
 
     assert result == {

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -2,13 +2,101 @@ import pytest
 from geocoder import build_enrichment_fields
 
 
-def test_build_enrichment_fields_returns_fields():
+def test_build_enrichment_fields_returns_fields_both_srids():
     config = {
         "enrichment_fields": [
             "census_tract_2020",
             "census_block_group_2020",
             "census_block_2020",
-        ]
+        ],
+        "srid_4326": True,
+        "srid_2272": True,
+    }
+
+    expected = (
+        {"census_tract_2020", "census_block_group_2020", "census_block_2020"},
+        {
+            "census_tract_2020",
+            "census_block_group_2020",
+            "census_block_2020",
+            "street_address",
+            "geocode_lat",
+            "geocode_lon",
+            "geocode_x",
+            "geocode_y"
+        },
+    )
+
+    actual = build_enrichment_fields(config)
+
+    assert expected == actual
+
+
+def test_build_enrichment_fields_returns_fields_only_4326():
+    config = {
+        "enrichment_fields": [
+            "census_tract_2020",
+            "census_block_group_2020",
+            "census_block_2020",
+        ],
+        "srid_4326": True,
+        "srid_2272": False,
+    }
+
+    expected = (
+        {"census_tract_2020", "census_block_group_2020", "census_block_2020"},
+        {
+            "census_tract_2020",
+            "census_block_group_2020",
+            "census_block_2020",
+            "street_address",
+            "geocode_lat",
+            "geocode_lon",
+        },
+    )
+
+    actual = build_enrichment_fields(config)
+
+    assert expected == actual
+
+
+def test_build_enrichment_fields_returns_fields_only_2272():
+    config = {
+        "enrichment_fields": [
+            "census_tract_2020",
+            "census_block_group_2020",
+            "census_block_2020",
+        ],
+        "srid_4326": False,
+        "srid_2272": True,
+    }
+
+    expected = (
+        {"census_tract_2020", "census_block_group_2020", "census_block_2020"},
+        {
+            "census_tract_2020",
+            "census_block_group_2020",
+            "census_block_2020",
+            "street_address",
+            "geocode_x",
+            "geocode_y",
+        },
+    )
+
+    actual = build_enrichment_fields(config)
+
+    assert expected == actual
+
+
+def test_build_enrichment_fields_defaults_to_both_srids():
+    """Test that when srid flags are not specified, both are included by default"""
+    config = {
+        "enrichment_fields": [
+            "census_tract_2020",
+            "census_block_group_2020",
+            "census_block_2020",
+        ],
+        # No srid_4326 or srid_2272 specified - should default to True
     }
 
     expected = (
@@ -37,7 +125,9 @@ def test_build_enrichment_fields_errors_if_invalid_field():
             "latitude",
             "longitude",
             "census_block_2020",
-        ]
+        ],
+        "srid_4326": True,
+        "srid_2272": True,
     }
 
     with pytest.raises(ValueError):

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -88,7 +88,7 @@ def test_build_enrichment_fields_returns_fields_only_2272():
     assert expected == actual
 
 
-def test_build_enrichment_fields_defaults_to_both_srids():
+def test_build_enrichment_fields_defaults_to_neither_srid():
     """Test that when srid flags are not specified, both are included by default"""
     config = {
         "enrichment_fields": [
@@ -106,10 +106,6 @@ def test_build_enrichment_fields_defaults_to_both_srids():
             "census_block_group_2020",
             "census_block_2020",
             "street_address",
-            "geocode_lat",
-            "geocode_lon",
-            "geocode_x",
-            "geocode_y"
         },
     )
 

--- a/tests/test_tomtom_lookup.py
+++ b/tests/test_tomtom_lookup.py
@@ -33,10 +33,148 @@ json_response_match = {
     ],
 }
 
+json_response_match_2272 = {
+    "spatialReference": {"wkid": 2272, "latestWkid": 2272},
+    "candidates": [
+        {
+            "address": "1234 Market St, Philadelphia, Pennsylvania, 19107",
+            "location": {"x": 2694393.35, "y": 235982.72},
+            "score": 100,
+            "attributes": {},
+        }
+    ],
+}
+
 json_response_nonmatch = {
     "spatialReference": {"wkid": 4326, "latestWkid": 4326},
     "candidates": [],
 }
+
+
+def test_tomtom_lookup_fetches_both_srids(monkeypatch):
+    call_count = {"count": 0}
+
+    class FakeResponse:
+        def __init__(self, data, status_code=200):
+            self._data = data
+            self.status_code = status_code
+
+        def json(self):
+            return self._data
+
+    class FakeSession:
+        def get(self, *a, **k):
+            raise AssertionError("Should be patched")
+
+    def fake_get(self, url, params=None, timeout=None, **kwargs):
+        call_count["count"] += 1
+        # First call - SRID 4326
+        if call_count["count"] == 1:
+            return FakeResponse(json_response_match, 200)
+        # Second call - SRID 2272
+        else:
+            return FakeResponse(json_response_match_2272, 200)
+
+    monkeypatch.setattr(FakeSession, "get", fake_get)
+    sess = FakeSession()
+
+    result = tomtom_lookup.tomtom_lookup(
+        sess, p, ["19107"], "1234 Market St", "1234 MARKET ST",
+        fetch_4326=True, fetch_2272=True
+    )
+
+    assert result == {
+        "geocode_lat": "39.951918251135154",
+        "geocode_lon": "-75.16047189802985",
+        "geocode_x": "2694393.35",
+        "geocode_y": "235982.72",
+        "is_addr": True,
+        "is_philly_addr": True,
+        "output_address": "1234 MARKET ST",
+        "match_type": "tomtom",
+    }
+
+
+def test_tomtom_lookup_only_fetches_4326(monkeypatch):
+    class FakeResponse:
+        def __init__(self, data, status_code=200):
+            self._data = data
+            self.status_code = status_code
+
+        def json(self):
+            return self._data
+
+    class FakeSession:
+        def get(self, *a, **k):
+            raise AssertionError("Should be patched")
+
+    def fake_get(self, url, params=None, timeout=None, **kwargs):
+        return FakeResponse(json_response_match, 200)
+
+    monkeypatch.setattr(FakeSession, "get", fake_get)
+    sess = FakeSession()
+
+    result = tomtom_lookup.tomtom_lookup(
+        sess, p, ["19107"], "1234 Market St", "1234 MARKET ST",
+        fetch_4326=True, fetch_2272=False
+    )
+
+    assert result == {
+        "geocode_lat": "39.951918251135154",
+        "geocode_lon": "-75.16047189802985",
+        "is_addr": True,
+        "is_philly_addr": True,
+        "output_address": "1234 MARKET ST",
+        "match_type": "tomtom",
+    }
+    # Ensure geocode_x and geocode_y are not in result
+    assert "geocode_x" not in result
+    assert "geocode_y" not in result
+
+
+def test_tomtom_lookup_only_fetches_2272(monkeypatch):
+    call_count = {"count": 0}
+
+    class FakeResponse:
+        def __init__(self, data, status_code=200):
+            self._data = data
+            self.status_code = status_code
+
+        def json(self):
+            return self._data
+
+    class FakeSession:
+        def get(self, *a, **k):
+            raise AssertionError("Should be patched")
+
+    def fake_get(self, url, params=None, timeout=None, **kwargs):
+        call_count["count"] += 1
+        # First call - initial lookup (always uses 4326 for address matching)
+        if call_count["count"] == 1:
+            return FakeResponse(json_response_match, 200)
+        # Second call - SRID 2272
+        else:
+            return FakeResponse(json_response_match_2272, 200)
+
+    monkeypatch.setattr(FakeSession, "get", fake_get)
+    sess = FakeSession()
+
+    result = tomtom_lookup.tomtom_lookup(
+        sess, p, ["19107"], "1234 Market St", "1234 MARKET ST",
+        fetch_4326=False, fetch_2272=True
+    )
+
+    assert result == {
+        "geocode_x": "2694393.35",
+        "geocode_y": "235982.72",
+        "is_addr": True,
+        "is_philly_addr": True,
+        "output_address": "1234 MARKET ST",
+        "match_type": "tomtom",
+    }
+    # Ensure geocode_lat and geocode_lon are not in result
+    assert "geocode_lat" not in result
+    assert "geocode_lon" not in result
 
 
 def test_false_address_returns_none_if_bad_address(monkeypatch):
@@ -65,7 +203,8 @@ def test_false_address_returns_none_if_bad_address(monkeypatch):
     sess = FakeSession()
 
     result = tomtom_lookup.tomtom_lookup(
-        sess, p, ["1111"], "1234 Fake St", "1234 FAKE ST"
+        sess, p, ["1111"], "1234 Fake St", "1234 FAKE ST",
+        fetch_4326=True, fetch_2272=True
     )
 
     assert result == {
@@ -78,3 +217,63 @@ def test_false_address_returns_none_if_bad_address(monkeypatch):
         "output_address": "1234 FAKE ST",
         "match_type": None,
     }
+
+
+def test_tomtom_lookup_handles_non_philly_address(monkeypatch):
+    call_count = {"count": 0}
+
+    class FakeResponse:
+        def __init__(self, data, status_code=200):
+            self._data = data
+            self.status_code = status_code
+
+        def json(self):
+            return self._data
+
+    class FakeSession:
+        def get(self, *a, **k):
+            raise AssertionError("Should be patched")
+
+    def fake_get(self, url, params=None, timeout=None, **kwargs):
+        call_count["count"] += 1
+        # Return the NJ address (second candidate)
+        if call_count["count"] == 1:
+            return FakeResponse({
+                "spatialReference": {"wkid": 4326, "latestWkid": 4326},
+                "candidates": [
+                    {
+                        "address": "1234 Market St, Gloucester City, New Jersey, 08030",
+                        "location": {"x": -75.11192847164241, "y": 39.88775918851947},
+                        "score": 100,
+                        "attributes": {},
+                    }
+                ],
+            }, 200)
+        else:
+            return FakeResponse({
+                "spatialReference": {"wkid": 2272, "latestWkid": 2272},
+                "candidates": [
+                    {
+                        "address": "1234 Market St, Gloucester City, New Jersey, 08030",
+                        "location": {"x": 2700000.00, "y": 240000.00},
+                        "score": 100,
+                        "attributes": {},
+                    }
+                ],
+            }, 200)
+
+    monkeypatch.setattr(FakeSession, "get", fake_get)
+    sess = FakeSession()
+
+    result = tomtom_lookup.tomtom_lookup(
+        sess, p, ["19107"], "1234 Market St", "1234 MARKET ST",
+        fetch_4326=True, fetch_2272=True
+    )
+
+    assert result["is_addr"] == True
+    assert result["is_philly_addr"] == False
+    assert result["match_type"] == "tomtom"
+    assert result["geocode_lat"] == "39.88775918851947"
+    assert result["geocode_lon"] == "-75.11192847164241"
+    assert result["geocode_x"] == "2700000.0"
+    assert result["geocode_y"] == "240000.0"

--- a/tests/test_tomtom_lookup.py
+++ b/tests/test_tomtom_lookup.py
@@ -8,7 +8,7 @@ json_response_match = {
     "candidates": [
         {
             "address": "1234 Market St, Philadelphia, Pennsylvania, 19107",
-            "location": {"x": -75.16047189802985, "y": 39.951918251135154},
+            "location": {"x": -75.11192847164241, "y": 39.88775918851947},
             "score": 100,
             "attributes": {},
             "extent": {
@@ -84,8 +84,8 @@ def test_tomtom_lookup_fetches_both_srids(monkeypatch):
     )
 
     assert result == {
-        "geocode_lat": "39.951918251135154",
-        "geocode_lon": "-75.16047189802985",
+        "geocode_lat": "39.88775919",
+        "geocode_lon": "-75.11192847",
         "geocode_x": "2694393.35",
         "geocode_y": "235982.72",
         "is_addr": True,
@@ -120,8 +120,8 @@ def test_tomtom_lookup_only_fetches_4326(monkeypatch):
     )
 
     assert result == {
-        "geocode_lat": "39.951918251135154",
-        "geocode_lon": "-75.16047189802985",
+        "geocode_lat": "39.88775919",
+        "geocode_lon": "-75.11192847",
         "is_addr": True,
         "is_philly_addr": True,
         "output_address": "1234 MARKET ST",
@@ -273,7 +273,7 @@ def test_tomtom_lookup_handles_non_philly_address(monkeypatch):
     assert result["is_addr"] == True
     assert result["is_philly_addr"] == False
     assert result["match_type"] == "tomtom"
-    assert result["geocode_lat"] == "39.88775918851947"
-    assert result["geocode_lon"] == "-75.11192847164241"
+    assert result["geocode_lat"] == "39.88775919"
+    assert result["geocode_lon"] == "-75.11192847"
     assert result["geocode_x"] == "2700000.0"
     assert result["geocode_y"] == "240000.0"

--- a/utils/tomtom_lookup.py
+++ b/utils/tomtom_lookup.py
@@ -5,6 +5,36 @@ from .parse_address import tag_full_address, flag_non_philly_address
 
 TOMTOM_RATE_LIMITER = RateLimiter(max_calls=10, period=1.0)
 
+def _fetch_tomtom_coordinates(
+    sess: requests.Session,
+    address: str,
+    srid: int
+) -> tuple[str, str]:
+    """
+    Helper function to fetch coordinates for a specific SRID.
+    Returns (coord1, coord2) or (None, None) if failed.
+    """
+    TOMTOM_RATE_LIMITER.wait()
+    tomtom_url = "https://citygeo-geocoder-aws.phila.city/arcgis/rest/services/TomTom/US_StreetAddress/GeocodeServer/findAddressCandidates"
+    params = {"Address": address, "f": "pjson", "outSR": str(srid)}
+    
+    response = sess.get(tomtom_url, params=params, timeout=10)
+    
+    if response.status_code >= 500:
+        raise Exception("5xx response. There may be a problem with TomTom API server.")
+    elif response.status_code == 429:
+        raise Exception("429 response. Too many API calls to TomTom.")
+    
+    if response.status_code == 200 and response.json().get("candidates"):
+        r_json = response.json()["candidates"][0]
+        try:
+            coord1 = r_json["location"]["x"]
+            coord2 = r_json["location"]["y"]
+            return str(coord1), str(coord2)
+        except KeyError:
+            return None, None
+    
+    return None, None
 
 # Code adapted from Alex Waldman and Roland MacDavid
 # https://github.com/CityOfPhiladelphia/databridge-etl-tools/blob/master/databridge_etl_tools/ais_geocoder/ais_request.py
@@ -14,7 +44,13 @@ TOMTOM_RATE_LIMITER = RateLimiter(max_calls=10, period=1.0)
     stop_max_attempt_number=5,
 )
 def tomtom_lookup(
-    sess: requests.Session, parser, philly_zips: list, address: str, fallback_addr
+    sess: requests.Session, 
+    parser, 
+    philly_zips: list, 
+    address: str, 
+    fallback_addr,
+    fetch_4326: bool = True,
+    fetch_2272: bool = True,
 ) -> dict:
     """
     Given a passyunk-normalized address, looks up via TomTom.
@@ -26,6 +62,8 @@ def tomtom_lookup(
         tomtom output against
         address (str): The address to query
         fallback_addr (str): The address to return if no match is found
+        fetch_4326 (bool): Whether or not to pull coordinates in 4326
+        fetch_2272 (bool): Whether or not to pull coordinates in 2272
 
     Returns:
         A dict with standardized address, latitude and longitude, returned
@@ -48,85 +86,40 @@ def tomtom_lookup(
         )
 
     out_data = {}
-    if response.status_code == 200:
-        # TomTom returns an empty list if no addresses match
-        if response.json().get("candidates"):
-            # First response should be most probable match,
-            # so hopefully no need to tiebreak.
-            r_json = response.json()["candidates"][0]
-            address = r_json.get("address", "")
+            # TomTom returns an empty list if no addresses match
+    if response.status_code == 200 and response.json().get("candidates"):
+        # First response should be most probable match,
+        # so hopefully no need to tiebreak.
+        r_json = response.json()["candidates"][0]
+        matched_address = r_json.get("address", "")
+        address_tagged = tag_full_address(matched_address)
+        address_flagged = flag_non_philly_address(address_tagged, philly_zips)
+        is_philly_addr = not address_flagged["is_non_philly"]
 
+        parsed_address = parser.parse(matched_address).get("components", "").get("output_address", "")
+        out_data["output_address"] = parsed_address if parsed_address else matched_address
+        out_data["match_type"] = "tomtom"
+        out_data["is_addr"] = True
+        out_data["is_philly_addr"] = is_philly_addr
+
+        if fetch_4326:
             try:
                 lon = r_json["location"]["x"]
                 lat = r_json["location"]["y"]
-
+                out_data["geocode_lat"] = str(round(float(lat), 8))
+                out_data["geocode_lon"] = str(round(float(lon), 8))
             except KeyError:
-                lon, lat = ""
+                out_data["geocode_lat"] = None
+                out_data["geocode_lon"] = None
+        
+        if fetch_2272:
+            geo_x, geo_y = _fetch_tomtom_coordinates(sess, matched_address, 2272)
+            out_data["geocode_x"] = str(round(float(geo_x), 8))
+            out_data["geocode_y"] = str(round(float(geo_y), 8))
+        
+        return out_data
 
-            # TomTom returns addresses as a full string. We need to
-            # determine whether or not the full address is in Philadelphia,
-            # so we use the usaddress module.
-            address_tagged = tag_full_address(address)
-
-            address_flagged = flag_non_philly_address(address_tagged, philly_zips)
-
-            is_philly_addr = not address_flagged["is_non_philly"]
-
-            parsed_address = (
-                parser.parse(address).get("components", "").get("output_address", "")
-            )
-            out_data["output_address"] = parsed_address if parsed_address else address
-            out_data["geocode_lat"] = str(lat)
-            out_data["geocode_lon"] = str(lon)
-            out_data["geocode_x"] = None
-            out_data["geocode_y"] = None
-            out_data["match_type"] = "tomtom"
-            out_data["is_addr"] = True
-            out_data["is_philly_addr"] = is_philly_addr
-
-            # ---- Make Second Request to Get SRID 2272 ---- #
-            # Need to specify json format, HTML by default
-            params = {"Address": address, "f": "pjson", "outSR": "2272"}
-
-            TOMTOM_RATE_LIMITER.wait()
-            response = sess.get(tomtom_url, params=params, timeout=10)
-
-            if response.status_code >= 500:
-                raise Exception("5xx response. There may be a problem with TomTom API server.")
-            
-            # 429 response indicates we're being blocked by the API.
-            elif response.status_code == 429:
-                raise Exception(
-                    "429 response. Too many API calls to TomTom in a short amount of time."
-                )
-            
-            if response.status_code == 200:
-                # TomTom returns an empty list if no addresses match
-                if response.json().get("candidates"):
-                    # First response should be most probable match,
-                    # so hopefully no need to tiebreak.
-                    r_json = response.json()["candidates"][0]
-
-                    try:
-                        geo_x = r_json["location"]["x"]
-                        geo_y = r_json["location"]["y"]
-                        out_data["geocode_x"] = str(geo_x)
-                        out_data["geocode_y"] = str(geo_y)
-
-                    except KeyError:
-                        out_data["geocode_x"] = None
-                        out_data["geocode_y"] = None
-                else:
-                    out_data["geocode_x"] = None
-                    out_data["geocode_y"] = None
-            else:
-                out_data["geocode_x"] = None
-                out_data["geocode_y"] = None
-
-            return out_data
-
-    # If no match, return none. Use a passyunk-parsed address if possible,
-    # otherwise use the unparsed input address.
+    # If no match
     out_data["output_address"] = fallback_addr if fallback_addr else address
     out_data["geocode_lat"] = None
     out_data["geocode_lon"] = None

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,7 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.14.9" },
     { name = "setuptools", specifier = ">=80.9.0" },
     { name = "usaddress", specifier = ">=0.5.16" },
-    { name = "wheel", specifier = ">=0.45.1" },
+    { name = "wheel", specifier = ">=0.46.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
The following PR enables and requires the user to specify the SRID
to be returned by geocoding

* SRID is specified in the yaml file
* if srid_4326 ad srid_2272 in the yaml file are both false, the script
  will return an error. at least one must be present and true
* lat/lon and x/y returned by the apis are now rounded to 8 digits to
  match the address file output
* unit tests are updated to match the new functionality