### PR TITLE
Pass raw addresses to tomtom instead

### DIFF
--- a/geocoder.py
+++ b/geocoder.py
@@ -309,7 +309,7 @@ def enrich_with_ais(
     pl.Field("output_address", pl.String),
     pl.Field("is_addr", pl.Boolean),
     pl.Field("is_philly_addr", pl.Boolean),
-    pl.Field("is_multiple_match", pl.Boolean),  # These come BEFORE geocode fields
+    pl.Field("is_multiple_match", pl.Boolean),
     pl.Field("match_type", pl.String),
 ]
 
@@ -580,42 +580,6 @@ def process_csv(config_path) -> pl.LazyFrame:
 
         lf = parse_with_passyunk_parser(parser, passyunk_address_field, lf)
 
-        # After parsing with Passyunk, rebuild joined_address using the cleaned output_address
-        # Only do this for split address fields (street/city/state/zip)
-        # Don't do this for full_address fields, as Passyunk strips city/state
-        if "street" in address_fields.keys():
-            # Build list of available location components
-            location_components = []
-            for key in ["city", "state", "zip"]:
-                if key in address_fields.keys() and address_fields[key] is not None:
-                    location_components.append(
-                        pl.col(address_fields[key]).fill_null("")
-                    )
-
-            lf = lf.with_columns(
-                pl.when(pl.col("output_address").is_not_null())
-                .then(
-                    pl.concat_str(
-                        [pl.col("output_address")] + location_components,
-                        separator=" ",
-                    )
-                    .str.replace_all(r"\s+", " ")
-                    .str.strip_chars()
-                )
-                .otherwise(pl.col(passyunk_address_field))
-                .alias("joined_address"),
-
-                pl.concat_str(
-                [pl.col("raw_address")] + location_components,
-                separator=" ",
-                ).str.replace_all(r"\s+", " ")\
-                    .str.strip_chars()\
-                        .alias("raw_address"),  # overwrite raw_address in place
-            )
-        else:
-            # For full_address cases, use the original field as joined_address
-            lf = lf.with_columns(pl.col(passyunk_address_field).alias("joined_address"))
-
         # ---------------- Split out Non Philly Addresses -------------------#
         philly_lf, non_philly_lf = split_non_philly_address(config_path, lf)
 
@@ -658,7 +622,7 @@ def process_csv(config_path) -> pl.LazyFrame:
             pl.concat([has_geo, tomtom_enriched])
             .sort("__geocode_idx__")
             .drop(
-                ["__geocode_idx__", "joined_address", "is_non_philly", "is_undefined", "raw_address"]
+                ["__geocode_idx__", "is_non_philly", "is_undefined", "raw_address"]
             )
         )
 

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -243,10 +243,15 @@ def ais_lookup(
             out_data["output_address"] = normalized_addr if normalized_addr else address
             out_data["is_addr"] = False
             out_data["is_philly_addr"] = True
-            out_data["geocode_lat"] = None
-            out_data["geocode_lon"] = None
-            out_data["geocode_x"] = None
-            out_data["geocode_y"] = None
+
+            if fetch_4326:
+                out_data["geocode_lat"] = None
+                out_data["geocode_lon"] = None
+
+            if fetch_2272:
+                out_data["geocode_x"] = None
+                out_data["geocode_y"] = None
+            
             out_data["is_multiple_match"] = True
             out_data["match_type"] = "ais"
 
@@ -295,10 +300,14 @@ def ais_lookup(
     out_data["is_philly_addr"] = existing_is_philly_addr
     out_data["is_multiple_match"] = False
     out_data["match_type"] = None
-    out_data["geocode_lat"] = None
-    out_data["geocode_lon"] = None
-    out_data["geocode_x"] = None
-    out_data["geocode_y"] = None
+
+    if fetch_4326:
+        out_data["geocode_lat"] = None
+        out_data["geocode_lon"] = None
+
+    if fetch_2272:
+        out_data["geocode_x"] = None
+        out_data["geocode_y"] = None
 
     for field in enrichment_fields:
         out_data[field] = None

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -163,6 +163,8 @@ def _fetch_ais_coordinates(
                 return None, None
             
         return None, None
+    
+    return None, None
 
 # Code adapted from Alex Waldman and Roland MacDavid
 # https://github.com/CityOfPhiladelphia/databridge-etl-tools/blob/master/databridge_etl_tools/ais_geocoder/ais_request.py

--- a/utils/tomtom_lookup.py
+++ b/utils/tomtom_lookup.py
@@ -1,19 +1,9 @@
-import requests, re
+import requests
 from .rate_limiter import RateLimiter
 from retrying import retry
 from .parse_address import tag_full_address, flag_non_philly_address
 
 TOMTOM_RATE_LIMITER = RateLimiter(max_calls=10, period=1.0)
-
-def _has_house_number(address: str) -> bool:
-    """Check if an address string contains a house number. Used to 
-    determine whether or not Passyunk has stripped a house number
-    from the address."""
-
-    if address:
-        return bool(re.match(r"^\d+", address.strip()))
-
-    return False
 
 def _fetch_tomtom_coordinates(
     sess: requests.Session,

--- a/utils/tomtom_lookup.py
+++ b/utils/tomtom_lookup.py
@@ -1,9 +1,19 @@
-import requests
+import requests, re
 from .rate_limiter import RateLimiter
 from retrying import retry
 from .parse_address import tag_full_address, flag_non_philly_address
 
 TOMTOM_RATE_LIMITER = RateLimiter(max_calls=10, period=1.0)
+
+def _has_house_number(address: str) -> bool:
+    """Check if an address string contains a house number. Used to 
+    determine whether or not Passyunk has stripped a house number
+    from the address."""
+
+    if address:
+        return bool(re.match(r"^\d+", address.strip()))
+
+    return False
 
 def _fetch_tomtom_coordinates(
     sess: requests.Session,
@@ -35,6 +45,68 @@ def _fetch_tomtom_coordinates(
             return None, None
     
     return None, None
+
+def _do_tomtom_lookup(
+    sess: requests.Session,
+    parser,
+    philly_zips: list,
+    address: str,
+    fetch_4326: bool,
+    fetch_2272: bool,
+    match_type: str = "tomtom",
+) -> dict:
+    """
+    Makes a single TomTom request and returns a populated out_data dict,
+    or None if no match.
+    """
+
+    if not address:
+        return None 
+    
+    TOMTOM_RATE_LIMITER.wait()
+    tomtom_url = "https://citygeo-geocoder-aws.phila.city/arcgis/rest/services/TomTom/US_StreetAddress/GeocodeServer/findAddressCandidates"
+    params = {"Address": address, "f": "pjson", "outSR": "4326"}
+
+    response = sess.get(tomtom_url, params=params, timeout=10)
+
+    if response.status_code >= 500:
+        raise Exception("5xx response. There may be a problem with TomTom API server.")
+    elif response.status_code == 429:
+        raise Exception("429 response. Too many API calls to TomTom.")
+
+    if response.status_code == 200 and response.json().get("candidates"):
+        r_json = response.json()["candidates"][0]
+        matched_address = r_json.get("address", "")
+        address_tagged = tag_full_address(matched_address)
+        address_flagged = flag_non_philly_address(address_tagged, philly_zips)
+        is_philly_addr = not address_flagged["is_non_philly"]
+
+        parsed_address = parser.parse(matched_address).get("components", "").get("output_address", "")
+
+        out_data = {}
+        out_data["output_address"] = parsed_address if parsed_address else matched_address
+        out_data["match_type"] = match_type
+        out_data["is_addr"] = True
+        out_data["is_philly_addr"] = is_philly_addr
+
+        if fetch_4326:
+            try:
+                lon = r_json["location"]["x"]
+                lat = r_json["location"]["y"]
+                out_data["geocode_lat"] = str(round(float(lat), 8))
+                out_data["geocode_lon"] = str(round(float(lon), 8))
+            except KeyError:
+                out_data["geocode_lat"] = None
+                out_data["geocode_lon"] = None
+
+        if fetch_2272:
+            geo_x, geo_y = _fetch_tomtom_coordinates(sess, matched_address, 2272)
+            out_data["geocode_x"] = str(round(float(geo_x), 8))
+            out_data["geocode_y"] = str(round(float(geo_y), 8))
+
+        return out_data
+
+    return None
 
 # Code adapted from Alex Waldman and Roland MacDavid
 # https://github.com/CityOfPhiladelphia/databridge-etl-tools/blob/master/databridge_etl_tools/ais_geocoder/ais_request.py
@@ -69,64 +141,25 @@ def tomtom_lookup(
         A dict with standardized address, latitude and longitude, returned
         from TomTom.
     """
-    TOMTOM_RATE_LIMITER.wait()
-    tomtom_url = "https://citygeo-geocoder-aws.phila.city/arcgis/rest/services/TomTom/US_StreetAddress/GeocodeServer/findAddressCandidates"
-
-    # Need to specify json format, HTML by default
-    params = {"Address": address, "f": "pjson", "outSR": "4326"}
-
-    response = sess.get(tomtom_url, params=params, timeout=10)
-
-    if response.status_code >= 500:
-        raise Exception("5xx response. There may be a problem with TomtomAPI server.")
-    # 429 response indicates we're being blocked by the API.
-    elif response.status_code == 429:
-        raise Exception(
-            "429 response. Too many API callsto TomTom in a short amount of time."
-        )
-
-    out_data = {}
-            # TomTom returns an empty list if no addresses match
-    if response.status_code == 200 and response.json().get("candidates"):
-        # First response should be most probable match,
-        # so hopefully no need to tiebreak.
-        r_json = response.json()["candidates"][0]
-        matched_address = r_json.get("address", "")
-        address_tagged = tag_full_address(matched_address)
-        address_flagged = flag_non_philly_address(address_tagged, philly_zips)
-        is_philly_addr = not address_flagged["is_non_philly"]
-
-        parsed_address = parser.parse(matched_address).get("components", "").get("output_address", "")
-        out_data["output_address"] = parsed_address if parsed_address else matched_address
-        out_data["match_type"] = "tomtom"
-        out_data["is_addr"] = True
-        out_data["is_philly_addr"] = is_philly_addr
-
-        if fetch_4326:
-            try:
-                lon = r_json["location"]["x"]
-                lat = r_json["location"]["y"]
-                out_data["geocode_lat"] = str(round(float(lat), 8))
-                out_data["geocode_lon"] = str(round(float(lon), 8))
-            except KeyError:
-                out_data["geocode_lat"] = None
-                out_data["geocode_lon"] = None
-        
-        if fetch_2272:
-            geo_x, geo_y = _fetch_tomtom_coordinates(sess, matched_address, 2272)
-            out_data["geocode_x"] = str(round(float(geo_x), 8))
-            out_data["geocode_y"] = str(round(float(geo_y), 8))
-        
+    out_data = _do_tomtom_lookup(sess, parser, philly_zips, address, fetch_4326, fetch_2272)
+    
+    if out_data is not None:
         return out_data
 
-    # If no match
-    out_data["output_address"] = fallback_addr if fallback_addr else address
-    out_data["geocode_lat"] = None
-    out_data["geocode_lon"] = None
-    out_data["geocode_x"] = None
-    out_data["geocode_y"] = None
-    out_data["match_type"] = None
-    out_data["is_addr"] = False
-    out_data["is_philly_addr"] = False
+    # Truly no match
+    out_data = {
+        "output_address": fallback_addr if fallback_addr else address,
+        "match_type": None,
+        "is_addr": False,
+        "is_philly_addr": False,
+    }
 
+    if fetch_4326:
+        out_data["geocode_lat"] = None
+        out_data["geocode_lon"] = None
+    
+    if fetch_2272:
+        out_data["geocode_x"] = None
+        out_data["geocode_y"] = None
+    
     return out_data


### PR DESCRIPTION
Instead of passing passyunk parsed addresses, pass raw addresses to tomtom instead

Avoid potential schema errors by having code correctly return columns based on whether user has specified 4326 or 2272