### PR TITLE
Check for full address before checking split address fields

### DIFF
--- a/utils/parse_address.py
+++ b/utils/parse_address.py
@@ -162,7 +162,7 @@ def find_address_fields(config) -> dict[str]:
     # if address is stored in multiple columns.
     full_addr = config.get("full_address_field")
 
-    addr_fields = config.get("address_fields")
+    addr_fields = config.get("address_fields") or {}
 
     # street_address used to be called street, adding this for backward compatibility
     # in case someone hasn't updated their config file to call it street_address
@@ -200,7 +200,10 @@ def find_address_fields(config) -> dict[str]:
             else:
                 print("Exiting program...")
                 sys.exit()
-
+    
+    if full_addr:
+        return {"full_address": full_addr}
+    
     if not addr_fields.get("street_address"):
         raise ValueError(
             "When full address field is not specified, "


### PR DESCRIPTION
Closes #38 

Provides a blank `addr_fields` in case it is not supplied.
If only `full_address` is provided, returns before raising error about not having a split address field.