### PR TITLE
50 bug errors are not caught from tiebroken address failing on coord lookup results

### DIFF
--- a/geocoder.py
+++ b/geocoder.py
@@ -576,7 +576,8 @@ def process_csv(config_path):
         # fails to match
         lf = lf.with_columns(pl.col(passyunk_address_field).alias("raw_address"))
 
-        lf = parse_with_passyunk_parser(parser, passyunk_address_field, lf)
+        # Collect to avoid calling passyunk parser multiple times
+        lf = parse_with_passyunk_parser(parser, passyunk_address_field, lf).collect().lazy()
 
         # After parsing with Passyunk, rebuild joined_address using the cleaned output_address
         # Only do this for split address fields (street/city/state/zip)
@@ -634,9 +635,12 @@ def process_csv(config_path):
         has_geo, needs_geo = split_geos(joined_lf, config)
 
         uses_full_address = bool(address_fields.get("full_address"))
+
+        # Collect and then convert back to lazy df to avoid multiple
         ais_enriched = enrich_with_ais(
             config, needs_geo, uses_full_address, ais_enrichment_fields
-        )
+        ).collect().lazy()
+        
 
         ais_rejoined = pl.concat([has_geo, ais_enriched]).sort("__geocode_idx__")
 
@@ -650,7 +654,7 @@ def process_csv(config_path):
             "__geocode_idx__"
         )
 
-        tomtom_enriched = enrich_with_tomtom(parser, config, needs_geo)
+        tomtom_enriched = enrich_with_tomtom(parser, config, needs_geo).collect().lazy()
 
         # -------------- Check TomTom matches against AIS again ---------------- #
         
@@ -668,7 +672,7 @@ def process_csv(config_path):
         tomtom_enriched_non_philly = tomtom_enriched.filter(pl.col("is_non_philly"))
         tomtom_enriched_is_philly = tomtom_enriched.filter(~pl.col("is_non_philly"))
 
-        ais_reinriched = enrich_with_ais(config, tomtom_enriched_is_philly, uses_full_address, ais_enrichment_fields)
+        ais_reinriched = enrich_with_ais(config, tomtom_enriched_is_philly, uses_full_address, ais_enrichment_fields).collect().lazy()
 
         reinriched_has_geo, reinriched_needs_geo = split_geos(ais_reinriched, config)
 

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -202,40 +202,26 @@ def ais_lookup(
     AIS_RATE_LIMITER.wait()
 
     # Don't attempt to geocode if address is null
-    if not address:
-        out_data = {
-            'output_address': original_address if original_address else address,
-            'is_addr': existing_is_addr,
-            'is_philly_addr': existing_is_philly_addr,
-            'is_multiple_match': False,
-            'geocoder_used': None,
-        }
+    if address:
+        try:
+            quoted_address = quote(address)
+            ais_url = "https://api.phila.gov/ais/v1/search/" + quoted_address + f"?gatekeeperKey={api_key}&srid=4326&max_range=0"
+            response = sess.get(ais_url, verify=False)
+        except:
+            print(f'ERROR: This address cannot be quoted: {address}, {zip}, {original_address}')
+            response = None
+    else:
+        response = None
 
-        if fetch_4326:
-            out_data["geocode_lat"] = None
-            out_data["geocode_lon"] = None
-        
-        if fetch_2272:
-            out_data["geocode_x"] = None
-            out_data["geocode_y"] = None
-        
-        for field in enrichment_fields:
-            out_data[field] = None
-        
-        return out_data
-
-    ais_url = "https://api.phila.gov/ais/v1/search/" + quote(address) + f"?gatekeeperKey={api_key}&srid=4326&max_range=0" 
-    response = sess.get(ais_url, verify=False)
-
-    if response.status_code >= 500:
+    if response and response.status_code >= 500:
         raise Exception("5xx response. There may be a problem with the AIS API.")
-    elif response.status_code == 429:
+    elif response and response.status_code == 429:
         raise Exception("429 response. Too many calls to the AIS API.")
 
     out_data = {}
     # If status code is 200, that means API has found a match.
     # API will return a 404 if no match
-    if response.status_code == 200:
+    if response and response.status_code == 200:
         # If r_json is longer than 1, multiple matches
         # were returned and we need to tiebreak
         r_json = response.json()

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -10,7 +10,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 AIS_RATE_LIMITER = RateLimiter(max_calls=5, period=1.0)
 
 
-def tiebreak(response: dict, zip) -> dict:
+def tiebreak(features: list[dict], zip, strict: bool = False) -> dict:
     """
     If more than one result is returned by AIS, tiebreak by checking zip code.
     If no zip code is provided, return None and a flag that indicates a
@@ -20,13 +20,15 @@ def tiebreak(response: dict, zip) -> dict:
         response (dict): An AIS API response
         zip (str): The zip code present on the input data. Used
         to check API responses against.
+        strict (bool): Whether or not to return the first address or none
+        if there is more than one match
 
     Returns:
         A dict with the zipcode-matched record, or if no match, None.
     """
 
     candidates = []
-    for candidate in response.json()["features"]:
+    for candidate in features:
         # If the AIS API zip code matches the zip code on the
         # incoming data, this record is a potential match
         if candidate["properties"].get("zip_code", "") == zip:
@@ -36,11 +38,15 @@ def tiebreak(response: dict, zip) -> dict:
     # should write code in the future to more intelligently tiebreak
     # and behaves differently based on if the two addresses returned
     # are actually the same
-    if len(candidates) == 1:
-        return candidates[0]
 
-    else:
-        return None
+    if candidates:
+        if strict:
+            return candidates[0] if len(candidates) == 1 else None
+    
+        else:
+            return candidates[0]
+
+    return None
 
 
 def get_intersection_coords(ais_dict: dict) -> list[str, str]:
@@ -104,25 +110,6 @@ def make_coordinate_lookups(
 
     return out_data
 
-
-def tiebreak_coordinate_lookups(responses: list[dict], zip: str):
-    addresses = []
-
-    for response in responses:
-        candidates = response.get("features")
-        # If the AIS API zip code matches the zip code on the
-        # incoming data, this record is a potential match
-        for candidate in candidates:
-            if candidate["properties"].get("zip_code", "") == zip or not zip:
-                addresses.append(candidate)
-
-    # Sometimes AIS returns two addresses for the same lat lon
-    # should write code in the future to more intelligently tiebreak
-    # and behaves differently based on if the two addresses returned
-    # are actually the same
-    if addresses:
-        return addresses[0]
-
 def _round_coordinates(coord) -> str:
     """Round and stringify a coordinate value, returning None if invalid."""
     try:
@@ -159,7 +146,7 @@ def _fetch_ais_coordinates(
 
             # Tiebreak if multiple results
             if len(r_json["features"]) > 1:
-                feature = tiebreak(response, zip)
+                feature = tiebreak(r_json["features"], zip)
                 if not feature:
                     return None, None
                 
@@ -171,6 +158,14 @@ def _fetch_ais_coordinates(
             
         return None, None
 
+# Code adapted from Alex Waldman and Roland MacDavid
+# https://github.com/CityOfPhiladelphia/databridge-etl-tools/blob/master/databridge_etl_tools/ais_geocoder/ais_request.py
+@retry(
+    wait_exponential_multiplier=1000,
+    wait_exponential_max=10000,
+    stop_max_attempt_number=3,
+    wait_fixed=200,
+)
 # Code adapted from Alex Waldman and Roland MacDavid
 # https://github.com/CityOfPhiladelphia/databridge-etl-tools/blob/master/databridge_etl_tools/ais_geocoder/ais_request.py
 @retry(
@@ -211,39 +206,59 @@ def ais_lookup(
     AIS_RATE_LIMITER.wait()
 
     # Don't attempt to geocode if address is null
-    if address:
-        try:
-            quoted_address = quote(address)
-            ais_url = "https://api.phila.gov/ais/v1/search/" + quoted_address + f"?gatekeeperKey={api_key}&srid=4326&max_range=0"
-            response = sess.get(ais_url, verify=False)
-        except:
-            print(f'ERROR: This address cannot be quoted: {address}, {zip}, {original_address}')
-            response = None
-    else:
-        response = None
+    if not address:
+        out_data = {
+            'output_address': original_address if original_address else address,
+            'is_addr': existing_is_addr,
+            'is_philly_addr': existing_is_philly_addr,
+            'is_multiple_match': False,
+            'geocoder_used': None,
+        }
 
-    if response and response.status_code >= 500:
+        if fetch_4326:
+            out_data["geocode_lat"] = None
+            out_data["geocode_lon"] = None
+        
+        if fetch_2272:
+            out_data["geocode_x"] = None
+            out_data["geocode_y"] = None
+        
+        for field in enrichment_fields:
+            out_data[field] = None
+        
+        return out_data
+
+    ais_url = "https://api.phila.gov/ais/v1/search/" + quote(address) + f"?gatekeeperKey={api_key}&srid=4326&max_range=0" 
+    response = sess.get(ais_url, verify=False)
+
+    if response.status_code >= 500:
         raise Exception("5xx response. There may be a problem with the AIS API.")
-    elif response and response.status_code == 429:
+    elif response.status_code == 429:
         print(response.text)
         raise Exception("429 response. Too many calls to the AIS API.")
 
     out_data = {}
     # If status code is 200, that means API has found a match.
     # API will return a 404 if no match
-    if response and response.status_code == 200:
+    if response.status_code == 200:
         # If r_json is longer than 1, multiple matches
         # were returned and we need to tiebreak
         r_json = response.json()
         tiebroken_address = None
 
         if len(r_json["features"]) > 1 and r_json.get("search_type") == "address":
-            tiebroken_address = tiebreak(response, zip)
+            tiebroken_address = tiebreak(r_json["features"], zip, strict=True)
 
         elif r_json.get("search_type") == "intersection":
             coord_pairs = get_intersection_coords(response.json())
-            coord_lookup_results = make_coordinate_lookups(sess, coord_pairs, api_key)
-            tiebroken_address = tiebreak_coordinate_lookups(coord_lookup_results, zip)
+            
+            try:
+                coord_lookup_results = make_coordinate_lookups(sess, coord_pairs, api_key)
+                # tiebreak in a non-strict manner for coord lookups
+                tiebroken_address = tiebreak(coord_lookup_results, zip)
+            
+            except:
+                print(f'ERROR: This address cannot be tiebroken: {address}, {zip}, {coord_pairs}')
 
         # if r_json is not longer than 1, no need to tiebreak
         elif len(r_json["features"]) == 1:

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -28,10 +28,15 @@ def tiebreak(features: list[dict], zip, strict: bool = False) -> dict:
     """
 
     candidates = []
+
+    # Match only on first five of zip
+    input_zip = zip[:5] if zip else ""
     for candidate in features:
+
         # If the AIS API zip code matches the zip code on the
         # incoming data, this record is a potential match
-        if candidate["properties"].get("zip_code", "") == zip:
+        candidate_zip = candidate.get("properties", {}).get("zip_code", "")
+        if candidate_zip == input_zip or not zip:
             candidates.append(candidate)
 
     # Sometimes AIS returns two addresses for the same lat lon
@@ -94,7 +99,6 @@ def make_coordinate_lookups(
         if response.status_code >= 500:
             raise Exception("5xx response. There may be a problem with the AIS API.")
         elif response.status_code == 429:
-            print(response.text)
             raise Exception("429 response. Too many calls to the AIS API.")
 
         elif response.status_code == 401:
@@ -107,7 +111,7 @@ def make_coordinate_lookups(
             raise ValueError(
                 f"Error occurred with the following status code: {response.status_code}"
             )
-
+         
     return out_data
 
 def _round_coordinates(coord) -> str:
@@ -158,14 +162,6 @@ def _fetch_ais_coordinates(
             
         return None, None
 
-# Code adapted from Alex Waldman and Roland MacDavid
-# https://github.com/CityOfPhiladelphia/databridge-etl-tools/blob/master/databridge_etl_tools/ais_geocoder/ais_request.py
-@retry(
-    wait_exponential_multiplier=1000,
-    wait_exponential_max=10000,
-    stop_max_attempt_number=3,
-    wait_fixed=200,
-)
 # Code adapted from Alex Waldman and Roland MacDavid
 # https://github.com/CityOfPhiladelphia/databridge-etl-tools/blob/master/databridge_etl_tools/ais_geocoder/ais_request.py
 @retry(
@@ -234,7 +230,6 @@ def ais_lookup(
     if response.status_code >= 500:
         raise Exception("5xx response. There may be a problem with the AIS API.")
     elif response.status_code == 429:
-        print(response.text)
         raise Exception("429 response. Too many calls to the AIS API.")
 
     out_data = {}
@@ -255,7 +250,9 @@ def ais_lookup(
             try:
                 coord_lookup_results = make_coordinate_lookups(sess, coord_pairs, api_key)
                 # tiebreak in a non-strict manner for coord lookups
-                tiebroken_address = tiebreak(coord_lookup_results, zip)
+                tiebroken_address = tiebreak([
+                    feature for r in coord_lookup_results for feature in r.get("features", [])
+                ], zip)
             
             except:
                 print(f'ERROR: This address cannot be tiebroken: {address}, {zip}, {coord_pairs}')

--- a/utils/parse_address.py
+++ b/utils/parse_address.py
@@ -239,23 +239,31 @@ def parse_address(parser, address: str) -> tuple[str, bool, bool]:
     and a boolean value indicating if the address is a valid Philadelphia
     address.
     """
-    prsd = parser.parse(address)
-    parsed = prsd["components"]
 
-    has_street_code = False
-    for street in ("street", "street_2"):
-        sc = parsed.get(street, {}).get("street_code")
-        if sc:
-            has_street_code = True
-            break
+    try:
+        prsd = parser.parse(address)
+        parsed = prsd["components"]
+    
+        has_street_code = False
+        for street in ("street", "street_2"):
+            sc = parsed.get(street, {}).get("street_code")
+            if sc:
+                has_street_code = True
+                break
 
-    # If address matches to a street code, it is a philly address
-    is_addr = bool(has_street_code)
-    is_philly_addr = bool(has_street_code)
+        # If address matches to a street code, it is a philly address
+        is_addr = bool(has_street_code)
+        is_philly_addr = bool(has_street_code)
 
-    output_address = (
-        parsed.get("output_address", address) if is_philly_addr else address
-    )
+        output_address = (
+            parsed.get("output_address", address) if is_philly_addr else address
+        )
+    
+    # Handle Passyunk parsing edge cases
+    except Exception as e:
+        output_address = address
+        is_addr = False
+        is_philly_addr = False
 
     return {
         "output_address": output_address,


### PR DESCRIPTION
* Consolidate tiebreak into one function to improve code legibility
* Fix tiebreak not processing coord lookup: Fixes a bug where tiebreak was not getting zip information from
coordinate lookups, resulting in addresses erroneously being marked as
non matching and sent to TomTom when they did in fact match.
* Collect Polars LazyFrame after each pipeline step to avoid duplicate processing issues associated with Polars' parallelization
* Error handling for edge cases where Passyunk fails to parse

**Identified issue:**

When AIS is given an intersection, it does an intersection lookup. Intersection lookups in AIS don't return all the fields we need back, but they do return coordinates. We do a secondary lookup of those coordinates to get a full address. Then we tiebreak the results.

The tiebreak logic wasn't working on the structure of the JSON returned by AIS' coordinate lookup endpoint, which differs from the regular address lookup endpoint, so tiebreaking returned null values for latitude and longitude.

If latitude and longitude are null, we assume that no match occurred, and send the address to be matched via TomTom.
When we match an address to TomTom, we then take the standardized address output by TomTom and use it to attempt to recover AIS data. This is because TomTom doesn't return the enrichment fields a user specifies, but AIS does. So it looked like addresses were getting retried, when what was really happening was that an address was first not getting marked as having matched to AIS, then passed through TomTom, then matched to AIS again.

**Fix:**
I've updated the tiebreak logic to properly unpack the response returned by the coordinate lookup end point.
A secondary contributing factor is how our tiebreak logic compares zips. In order to tiebreak, we check whether or not the incoming address has the same zip as the address returned by the API. If so, it's a match candidate. This wasn't taking into account that some zips might be in zip-9 format. So now it checks if the first 5 digits of the zips are the same.