### PR TITLE
FEATURE: Add shape string if specified 

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -28,4 +28,6 @@ enrichment_fields:
 
 # Which SRIDs to return for geocoding
 srid_4326: true
+shape_4326: false
 srid_2272: true
+shape_2272: false

--- a/geocoder.py
+++ b/geocoder.py
@@ -484,7 +484,6 @@ def enrich_with_tomtom(parser, config: dict, to_add: pl.LazyFrame) -> pl.LazyFra
 
     return added
 
-
 @click.command()
 @click.option(
     "--config_path",
@@ -509,6 +508,8 @@ def process_csv(config_path):
     
     srid_4326 = config.get("srid_4326")
     srid_2272 = config.get("srid_2272")
+    shape_4326 = config.get("shape_4326")
+    shape_2272 = config.get("shape_2272")
     
     if not srid_4326 and not srid_2272:
         raise ValueError(
@@ -516,6 +517,13 @@ def process_csv(config_path):
             "Set srid_4326 or srid_2272 to true in your config file."
         )
 
+    if (shape_4326 and not srid_4326) or (shape_2272 and not srid_2272):
+        raise ValueError(
+            "Invalid configuration: Enabled shape must match enabled SRID. \n "
+            "If shape_4326 is True, then srid_4326 must be true. If shape_2272 is True" \
+            ", then srid_2272 must be true."
+        )
+    
     filepath = config.get("input_file")
     geo_filepath = config.get("geography_file") or config.get("address_file")
 
@@ -736,7 +744,22 @@ def process_csv(config_path):
         
         # Drop raw address field, no longer need it after tomtom match
         rejoined = rejoined.select(ordered_cols)
-        
+
+        if shape_4326:
+            rejoined = rejoined.with_columns(
+                pl.struct(["geocode_lat", "geocode_lon"]).map_elements(
+                    lambda x: f"SRID=4326;POINT({x['geocode_lat']} {x['geocode_lon']})", 
+                    return_dtype=pl.String
+                ).alias("shape_4326")
+        )
+        if shape_2272:
+            rejoined = rejoined.with_columns(
+                pl.struct(["geocode_x", "geocode_y"]).map_elements(
+                    lambda x: f"SRID=2272;POINT({x['geocode_x']} {x['geocode_y']})", 
+                    return_dtype=pl.String
+                ).alias("shape_2272")
+        )
+
         # -------------------- Save Output File ---------------------- #
 
         in_path = PurePath(original_filepath)

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -8,7 +8,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 AIS_RATE_LIMITER = RateLimiter(max_calls=5, period=1.0)
-
+cached_responses = {}
 
 def tiebreak(features: list[dict], zip, strict: bool = False) -> dict:
     """
@@ -200,8 +200,14 @@ def ais_lookup(
         and user-requested fields.
     """
     AIS_RATE_LIMITER.wait()
+    out_data = {}
 
-    # Don't attempt to geocode if address is null
+    # See if we already processed this address.
+    if address and address.lower() in cached_responses:
+        out_data = cached_responses[address.lower()]        
+        return out_data
+
+    # Don't attempt to geocode if address is null    
     if address:
         try:
             quoted_address = quote(address)
@@ -218,7 +224,6 @@ def ais_lookup(
     elif response and response.status_code == 429:
         raise Exception("429 response. Too many calls to the AIS API.")
 
-    out_data = {}
     # If status code is 200, that means API has found a match.
     # API will return a 404 if no match
     if response and response.status_code == 200:
@@ -268,6 +273,8 @@ def ais_lookup(
 
             for field in enrichment_fields:
                 out_data[field] = None
+            
+            cached_responses[address.lower()] = out_data
 
             return out_data
 
@@ -302,6 +309,8 @@ def ais_lookup(
             for field in enrichment_fields:
                 field_value = tiebroken_address.get("properties", "").get(field, "")
                 out_data[field] = str(field_value) if field_value else None
+
+            cached_responses[address.lower()] = out_data
 
             return out_data
 


### PR DESCRIPTION
# Change:

Allows two extra parameters in the config file:
1. **shape_4326**
2. **shape_2272**

If these parameters are _not_ specified, then behavior is the same as normal. If the parameters are specified, will construct a column named after the parameter that builds the string representation of the shape field. 

# Checks:
Will make sure that the parameter for the corresponding srid is also set to true. For example, you cannot specify shape_2272 if srid_2272 is False. Similarly you cannot specify shape_4326 is True if srid_4326 is False. 
