### PR TITLE
70 bug backend fails to find uploaded file from gui

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,9 +114,10 @@ def call_geocoder_backend(data, config):
 # Prevent app from rerunning when this is clicked
 @st.fragment
 def download_config(config):
+    config_for_download = {**config, "input_file": None} # Make input file none since streamlit cannot access full filepaths
     st.download_button(
         label="Download config",
-        data=yaml.dump(config),
+        data=yaml.dump(config_for_download),
         file_name="geocoder_config.yml",
     )
 

--- a/app.py
+++ b/app.py
@@ -97,6 +97,7 @@ def call_geocoder_backend(data, config):
         tmp_path = tmp.name
 
     try:
+        config = {**config, "input_file": tmp_path}
         result, utf8_filepath = process_data(tmp_path, config)
         try:
             df = result.collect()


### PR DESCRIPTION
Input file path is now null in saved config (was relative filepath before, which was breaking). User will now have to manually enter filepath for a saved config.