### PR TITLE
91 improvement add description of 4326 and 2272

### DIFF
--- a/app.py
+++ b/app.py
@@ -231,7 +231,13 @@ def render_config_form() -> dict:
             st.multiselect(
                 "Choose which coordinate system (SRID) to use when geocoding. Required.",
                 [4326, 2272],
-                key="srids"
+                key="srids",
+                format_func=lambda x: (
+                    "4326 - (WGS 84)"
+                    if x == 4326
+                    else "2272 - (NAD83 / Pennsylvania South State Plane)"
+                ),
+                help="The 4326 spatial reference identifier is the generic global standard, represented by latitudinal and longitudinal points. However, 2272 is optimized for Philadelphia addresses and minimizes geometrical distortion.",
             )
 
             enrichment_fields = st.multiselect(

--- a/app.py
+++ b/app.py
@@ -144,7 +144,6 @@ def render_config_form() -> dict:
                 preview_df = pd.read_csv(st.session_state["input_filepath"], nrows=5, encoding="utf-8-sig")
                 st.subheader(":blue[Preview (first 5 rows)]")
                 st.dataframe(preview_df)
-                st.session_state["input_loaded"]
             
             except FileNotFoundError as e:
                 st.session_state["file_not_found_error"] = f"Error: {e}"


### PR DESCRIPTION
**Changes:**

1. Added `format_func` parameter to the srid multiselect widget (app.py line 235). This parameter allows you to alter the displayed format of the options, while retaining their original values. 

For example, SRID 2272 now appears as _"2272 - (NAD83 / Pennsylvania South State Plane)"_, but programmatically its value is still the integer 2272. 

2. Added the `help` parameter to the srid multiselect widget (app.py line 240). This parameter displays a hoverable question mark that can provide additional context for the widget. In this case, I roughly explained the difference between 2272 and 4326. 
