### PR TITLE
Explain the address file in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ fields that the user supplies.
 6. Records that successfully match to TomTom are then rerun against AIS to try to recover enrichment fields, if those addresses are in philly
 7. The enriched file is then saved to the same directory as the input file.
 
-The release executable of the address geocoder automatically checks an s3 bucket for an updated version of the address file. The address file is published to s3 via airflow, using this DAG configuration: https://github.com/CityOfPhiladelphia/databridge-airflow-v2-configs/blob/main/citygeo/address_service_area_summary_public.yml.
+The address file is a local copy of Philadelphia address reference data that the geocoder uses for its first matching pass. Keeping this file on disk lets the geocoder add coordinates and enrichment fields for many records without sending every address to the AIS API, which makes large jobs faster and reduces API calls. The release executable automatically checks an s3 bucket for an updated version of the address file. The address file is published to s3 via airflow, using this DAG configuration: https://github.com/CityOfPhiladelphia/databridge-airflow-v2-configs/blob/main/citygeo/address_service_area_summary_public.yml.
 
 ## Questions?
 If you have questions about the geocoder that this FAQ cannot answer, feel free to contact citygeo at: maps@phila.gov


### PR DESCRIPTION
This updates the README to define the address file before the download/update details, explaining that it is a local copy of Philadelphia address reference data used for the geocoder's first matching pass. It also clarifies why the file is downloaded locally: it allows coordinates and enrichment fields to be added for many records without sending every address to the AIS API, which helps large jobs run faster and reduces API calls.

Verification: checked the README content with a targeted assertion and ran `git diff --check`.
