### PR TITLE
152 feature move ais to gatekeeper

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from ui.constants import ADDRESS_FILE, ENRICHMENT_FIELDS, HOW_TO_FILEPATH
 from ui.logic import filtered_options, ready_to_geocode, parse_config
 from ui.how_to import render_how_to_page
 from geocoder import Geocoder
-from pathlib import Path
+
 
 # UI Configurations
 # --------- Header and Title -------- #
@@ -174,6 +174,7 @@ def render_config_form() -> dict:
                     nrows=5,
                     encoding="utf-8-sig",
                     dtype="str",
+                    encoding_errors='ignore'
                 )
                 st.subheader(":blue[Preview (first 5 rows)]")
                 st.dataframe(preview_df)

--- a/geocoder.py
+++ b/geocoder.py
@@ -18,7 +18,7 @@ from utils.parse_address import (
     is_non_philly,
 )
 from utils.ais_lookup import ais_lookup, fetch_service_area_enrichment_data, validate_api_key
-from utils.tomtom_lookup import tomtom_lookup
+from utils.tomtom_lookup import tomtom_lookup, check_tomtom_url
 from utils.zips import ZIPS
 from mapping.ais_properties_fields import POSSIBLE_FIELDS
 from passyunk.parser import PassyunkParser
@@ -243,6 +243,7 @@ class Geocoder:
 
         self.parser: PassyunkParser = PassyunkParser()
         self.session: requests.Session = requests.Session()
+        self.tomtom_url = check_tomtom_url(self.session, self.api_key)
 
         # Programmatically generate other attributes
         self.address_fields: dict = find_address_fields(config)
@@ -651,6 +652,8 @@ class Geocoder:
         tomtom_lookup_args = {
             "sess": self.session,
             "parser": self.parser,
+            "api_key": self.api_key,
+            "tomtom_url": self.tomtom_url,
             "philly_zips": ZIPS,
             "address": api_address,
             "fallback_addr": record["raw_address"].upper(),
@@ -774,8 +777,9 @@ class Geocoder:
         appended to the filename.
         """
 
-        # Validate that the given API key works
+        # Validate that the given API key works for AIS and TomTom
         validate_api_key(self.session, self.api_key)
+        
 
         sink_path = Path(self.out_path).with_suffix(".tmp")
         if sink_path.exists():

--- a/geocoder.py
+++ b/geocoder.py
@@ -17,7 +17,7 @@ from utils.parse_address import (
     infer_city_state_field,
     is_non_philly,
 )
-from utils.ais_lookup import ais_lookup, fetch_service_area_enrichment_data
+from utils.ais_lookup import ais_lookup, fetch_service_area_enrichment_data, validate_api_key
 from utils.tomtom_lookup import tomtom_lookup
 from utils.zips import ZIPS
 from mapping.ais_properties_fields import POSSIBLE_FIELDS
@@ -773,6 +773,9 @@ class Geocoder:
         Output is written to the same directory as the input file, with ``_enriched``
         appended to the filename.
         """
+
+        # Validate that the given API key works
+        validate_api_key(self.session, self.api_key)
 
         sink_path = Path(self.out_path).with_suffix(".tmp")
         if sink_path.exists():

--- a/tests/test_ais_lookup.py
+++ b/tests/test_ais_lookup.py
@@ -398,7 +398,7 @@ def test_ais_lookup_returns_no_match_if_tiebreak_fails(monkeypatch):
 
     assert (
         created["url"]
-        == "https://api.phila.gov/ais/v1/search/1234%20mkt%20st?gatekeeperKey=1234&srid=4326&max_range=0"
+        == "https://api-prod.phila.gov/ais/v1/search/1234%20mkt%20st"
     )
     assert result == {
         "geocode_lat": None,

--- a/tests/test_tomtom_lookup.py
+++ b/tests/test_tomtom_lookup.py
@@ -83,6 +83,8 @@ def test_tomtom_lookup_fetches_both_srids(monkeypatch):
     result = tomtom_lookup.tomtom_lookup(
         sess,
         p,
+        "123",
+        "tomtom.com",
         ["19107"],
         "1234 Market St",
         "1234 MARKET ST",
@@ -124,6 +126,8 @@ def test_tomtom_lookup_only_fetches_4326(monkeypatch):
     result = tomtom_lookup.tomtom_lookup(
         sess,
         p,
+        "123",
+        "tomtom.com",
         ["19107"],
         "1234 Market St",
         "1234 MARKET ST",
@@ -174,6 +178,8 @@ def test_tomtom_lookup_only_fetches_2272(monkeypatch):
     result = tomtom_lookup.tomtom_lookup(
         sess,
         p,
+        "123",
+        "tomtom.com",
         ["19107"],
         "1234 Market St",
         "1234 MARKET ST",
@@ -222,6 +228,8 @@ def test_false_address_returns_none_if_bad_address(monkeypatch):
     result = tomtom_lookup.tomtom_lookup(
         sess,
         p,
+        "123",
+        "tomtom.com",
         ["1111"],
         "1234 Fake St",
         "1234 FAKE ST",
@@ -300,6 +308,8 @@ def test_tomtom_lookup_handles_non_philly_address(monkeypatch):
     result = tomtom_lookup.tomtom_lookup(
         sess,
         p,
+        "123",
+        "tomtom.com",
         ["19107"],
         "1234 Market St",
         "1234 MARKET ST",

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -124,7 +124,7 @@ def _lookup_service_area(sess: requests.Session, lat: int, lon: int, api_key: st
     params["gatekeeperKey"] = api_key
     params["client_id"] = api_key
 
-    response = sess.get(ais_url, params=params, timeout=10, verify=False)
+    response = sess.get(ais_url, params=params, timeout=10)
 
     if response.status_code >= 500:
         raise Exception("5xx response. There may be a problem with the AIS API.")
@@ -276,7 +276,7 @@ def _fetch_ais_coordinates(
     params["srid"] = srid
     params["max_range"] = 0
 
-    response = sess.get(ais_url, verify=False, params=params)
+    response = sess.get(ais_url, params=params)
 
     if response.status_code >= 500:
         raise Exception("5xx response. There may be a problem with the AIS API.")
@@ -353,7 +353,7 @@ def ais_lookup(
         params["max_range"] = 0
 
         try:
-            response = sess.get(ais_url, verify=False, params=params)
+            response = sess.get(ais_url, params=params)
         except:
             print(
                 f"Warning: AIS lookup failed for this address: {address}, {zip}, {original_address}"

--- a/utils/ais_lookup.py
+++ b/utils/ais_lookup.py
@@ -9,6 +9,7 @@ import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 AIS_RATE_LIMITER = RateLimiter(max_calls=5, period=1.0)
+CANARY_ADDRESS = "1234 Market St"
 
 
 @dataclass
@@ -23,6 +24,26 @@ class AISResult:
     geocode_x: str = field(default=None)
     geocode_y: str = field(default=None)
 
+
+# ------- Authenticate ------- #
+def validate_api_key(sess, api_key) -> None:
+    """
+    Used to determine whether a given API key is valid. Raises an error if not valid.
+
+    Args:
+        sess: A requests session object
+        api_key: The API key to test
+    """
+    params = {"gatekeeperKey": api_key, "client_id": api_key}
+    
+    try:
+        response = sess.get(f"https://api-prod.phila.gov/ais/v1/search/{quote(CANARY_ADDRESS)}", params=params)
+    
+    except requests.RequestException as e:
+        raise Exception(f"Couldn't connect to AIS.") from e
+    
+    if response.status_code == 401:
+        raise Exception("401 response. Invalid API key.")
 
 # ------- Helper Functions -------- #
 def tiebreak(features: list[dict], zip, strict: bool = False) -> dict:
@@ -95,9 +116,13 @@ def get_intersection_coords(ais_dict: dict) -> list[str, str]:
 )
 def _lookup_service_area(sess: requests.Session, lat: int, lon: int, api_key: str):
     AIS_RATE_LIMITER.wait()
-    ais_url = f"https://api.phila.gov/ais_doc/v1/service_areas/{lon},{lat}"
+    ais_url = f"https://api-prod.phila.gov/ais/v1/service_areas/{lon},{lat}"
     params = {}
+
+    # To handle backwards compatibility with people still using a gatekeeper key instead of
+    # a client ID, we set both params here
     params["gatekeeperKey"] = api_key
+    params["client_id"] = api_key
 
     response = sess.get(ais_url, params=params, timeout=10, verify=False)
 
@@ -240,9 +265,18 @@ def _fetch_ais_coordinates(
     """
 
     AIS_RATE_LIMITER.wait()
-    ais_url = f"https://api.phila.gov/ais/v1/search/{quote(address)}?gatekeeperKey={api_key}&srid={srid}&max_range=0"
+    ais_url = f"https://api-prod.phila.gov/ais/v1/search/{quote(address)}"
+    
+    params = {}
 
-    response = sess.get(ais_url, verify=False)
+    # To handle backwards compatibility with people still using a gatekeeper key instead of
+    # a client ID, we set both params here
+    params["gatekeeperKey"] = api_key
+    params["client_id"] = api_key
+    params["srid"] = srid
+    params["max_range"] = 0
+
+    response = sess.get(ais_url, verify=False, params=params)
 
     if response.status_code >= 500:
         raise Exception("5xx response. There may be a problem with the AIS API.")
@@ -307,14 +341,19 @@ def ais_lookup(
 
     # Don't attempt to geocode if address is null
     if address:
+        ais_url = f"https://api-prod.phila.gov/ais/v1/search/{quote(address)}"
+
+        params = {}
+
+        # To handle backwards compatibility with people still using a gatekeeper key instead of
+        # a client ID, we set both params here
+        params["gatekeeperKey"] = api_key
+        params["client_id"] = api_key
+        params["srid"] = 4326
+        params["max_range"] = 0
+
         try:
-            quoted_address = quote(address)
-            ais_url = (
-                "https://api.phila.gov/ais/v1/search/"
-                + quoted_address
-                + f"?gatekeeperKey={api_key}&srid=4326&max_range=0"
-            )
-            response = sess.get(ais_url, verify=False)
+            response = sess.get(ais_url, verify=False, params=params)
         except:
             print(
                 f"Warning: AIS lookup failed for this address: {address}, {zip}, {original_address}"
@@ -322,7 +361,7 @@ def ais_lookup(
             response = None
     else:
         response = None
-
+    
     if response and response.status_code >= 500:
         raise Exception("5xx response. There may be a problem with the AIS API.")
     elif response and response.status_code == 429:

--- a/utils/parse_address.py
+++ b/utils/parse_address.py
@@ -1,4 +1,3 @@
-import yaml
 import re
 import usaddress
 import sys
@@ -162,7 +161,7 @@ def find_address_fields(config) -> dict[str]:
             "address fields in the config file.\n"
             "Press 1 to use the full address.\n"
             "Press 2 to use the address fields.\n"
-            "Press or Q to quit.\n"
+            "Press any other key to quit.\n"
         )
 
         while resp.lower() not in ["1", "2", "q", "quit"]:

--- a/utils/tomtom_lookup.py
+++ b/utils/tomtom_lookup.py
@@ -5,18 +5,46 @@ from .parse_address import tag_full_address, flag_non_philly_address
 from .ais_lookup import _round_coordinates
 
 TOMTOM_RATE_LIMITER = RateLimiter(max_calls=10, period=1.0)
+CANARY_ADDRESS = "1234 Market St"
 
+def check_tomtom_url(
+        sess: requests.Session,
+        api_key: str):
+    """
+    Returns which tomtom URL to point to, depending on the API key provided by the user.
+    If the api key fails to validate against the newer gateway, return the fallback gateway
+    """
+
+    tomtom_url = "https://api-prod.phila.gov/TomTom/v1/findAddressCandidates"
+    params = {"client_id": api_key, "Address": CANARY_ADDRESS, "f": "pjson"}
+
+    response = sess.get(tomtom_url, params=params)
+
+    if response.status_code == 401:
+        fallback_tomtom_url = "https://citygeo-geocoder-aws.phila.city/arcgis/rest/services/TomTom/US_StreetAddress/GeocodeServer/findAddressCandidates"
+
+        new_response = sess.get(fallback_tomtom_url, params=params)
+
+        if new_response.status_code == 401:
+            raise Exception("Invalid API key.")
+        
+        return fallback_tomtom_url
+
+    return tomtom_url
 
 def _fetch_tomtom_coordinates(
-    sess: requests.Session, address: str, srid: int
+    sess: requests.Session, 
+    api_key: str,
+    tomtom_url: str,
+    address: str, 
+    srid: int
 ) -> tuple[str, str]:
     """
     Helper function to fetch coordinates for a specific SRID.
     Returns (coord1, coord2) or (None, None) if failed.
     """
     TOMTOM_RATE_LIMITER.wait()
-    tomtom_url = "https://citygeo-geocoder-aws.phila.city/arcgis/rest/services/TomTom/US_StreetAddress/GeocodeServer/findAddressCandidates"
-    params = {"Address": address, "f": "pjson", "outSR": str(srid)}
+    params = {"Address": address, "f": "pjson", "outSR": str(srid), "client_id": api_key}
 
     response = sess.get(tomtom_url, params=params, timeout=10)
 
@@ -40,6 +68,8 @@ def _fetch_tomtom_coordinates(
 def _do_tomtom_lookup(
     sess: requests.Session,
     parser,
+    api_key: str,
+    tomtom_url: str,
     philly_zips: list,
     address: str,
     fetch_4326: bool,
@@ -55,8 +85,7 @@ def _do_tomtom_lookup(
         return None
 
     TOMTOM_RATE_LIMITER.wait()
-    tomtom_url = "https://citygeo-geocoder-aws.phila.city/arcgis/rest/services/TomTom/US_StreetAddress/GeocodeServer/findAddressCandidates"
-    params = {"Address": address, "f": "pjson", "outSR": "4326"}
+    params = {"Address": address, "f": "pjson", "outSR": "4326", "client_id": api_key}
 
     response = sess.get(tomtom_url, params=params, timeout=10)
 
@@ -98,7 +127,7 @@ def _do_tomtom_lookup(
                 out_data["geocode_lon"] = None
 
         if fetch_2272:
-            geo_x, geo_y = _fetch_tomtom_coordinates(sess, matched_address, 2272)
+            geo_x, geo_y = _fetch_tomtom_coordinates(sess, api_key, tomtom_url, matched_address, 2272)
             out_data["geocode_x"] = _round_coordinates(geo_x)
             out_data["geocode_y"] = _round_coordinates(geo_y)
 
@@ -117,6 +146,8 @@ def _do_tomtom_lookup(
 def tomtom_lookup(
     sess: requests.Session,
     parser,
+    api_key: str,
+    tomtom_url: str,
     philly_zips: list,
     address: str,
     fallback_addr,
@@ -129,6 +160,10 @@ def tomtom_lookup(
     Args:
         sess (requests Session object): A requests library session object
         parser: A passyunk parser object, used to normalize output
+        api_key (str): The AIS API key, also used for TomTom
+        tomtom_url (str): The TomTom URL to use. 
+            Present for backwards compatibility with people using API keys 
+            that are not valid for the new Mulesoft gateway endpoint.
         philly_zips (list): A list of philadelphia zips to validate
         tomtom output against
         address (str): The address to query
@@ -141,7 +176,7 @@ def tomtom_lookup(
         from TomTom.
     """
     out_data = _do_tomtom_lookup(
-        sess, parser, philly_zips, address, fetch_4326, fetch_2272
+        sess, parser, api_key, tomtom_url, philly_zips, address, fetch_4326, fetch_2272
     )
 
     if out_data is not None:

--- a/utils/tomtom_lookup.py
+++ b/utils/tomtom_lookup.py
@@ -16,19 +16,12 @@ def check_tomtom_url(
     """
 
     tomtom_url = "https://api-prod.phila.gov/TomTom/v1/findAddressCandidates"
-    params = {"client_id": api_key, "Address": CANARY_ADDRESS, "f": "pjson"}
+    params = {"client_id": api_key, "gatekeeperKey": api_key, "Address": CANARY_ADDRESS, "f": "pjson"}
 
     response = sess.get(tomtom_url, params=params)
 
     if response.status_code == 401:
-        fallback_tomtom_url = "https://citygeo-geocoder-aws.phila.city/arcgis/rest/services/TomTom/US_StreetAddress/GeocodeServer/findAddressCandidates"
-
-        new_response = sess.get(fallback_tomtom_url, params=params)
-
-        if new_response.status_code == 401:
-            raise Exception("Invalid API key.")
-        
-        return fallback_tomtom_url
+        raise Exception("Invalid API key.")
 
     return tomtom_url
 
@@ -44,7 +37,7 @@ def _fetch_tomtom_coordinates(
     Returns (coord1, coord2) or (None, None) if failed.
     """
     TOMTOM_RATE_LIMITER.wait()
-    params = {"Address": address, "f": "pjson", "outSR": str(srid), "client_id": api_key}
+    params = {"Address": address, "f": "pjson", "outSR": str(srid), "client_id": api_key, "gatekeeperKey": api_key}
 
     response = sess.get(tomtom_url, params=params, timeout=10)
 
@@ -85,7 +78,7 @@ def _do_tomtom_lookup(
         return None
 
     TOMTOM_RATE_LIMITER.wait()
-    params = {"Address": address, "f": "pjson", "outSR": "4326", "client_id": api_key}
+    params = {"Address": address, "f": "pjson", "outSR": "4326", "client_id": api_key, "gatekeeperKey": api_key}
 
     response = sess.get(tomtom_url, params=params, timeout=10)
 


### PR DESCRIPTION
This PR does the following:

1. Changes the backend to point API requests toward the Mulesoft Gateway
2. Passes API key as as the `client_id` parameter (new API keys) and `gatekeeperKey` parameter (backwards compatibility for old API keys) for both AIS and TomTom
3. Instantly throws an error if the API key is not valid, as opposed to waiting until after the address file match
4. Updates unit tests and the end to end test to reflect the new API parameters and URLs
5. Fixes a bug where files with non utf-8 characters were breaking the preview load in the GUI

This fix is intended to get the new Mulesoft Gateway API keys up and working quickly, post GeoExchange Presentation

Future work should be done to clean up code and ensure that `ais_lookup.py` and `tomtom_lookup.py` behave similarly. Presently, the API key validation function in `tomtom_lookup.py` returns a URL, while the one in `ais_lookup.py` does not.

Acceptance/testing criteria:
1. Geocoding works correctly for an old API key
2. Geocoding works correctly for a new API key
3. Geocoding fails immediately for an invalid API key.
4. All unit tests pass
5. GUI works for a sample file (to be validated by me)